### PR TITLE
test: add two more parseable example songs

### DIFF
--- a/example/house_of_the_rising_sun.cho
+++ b/example/house_of_the_rising_sun.cho
@@ -1,0 +1,23 @@
+{title: The House of the Rising Sun}
+{subtitle: Traditional}
+{artist: The Animals}
+{key: Am}
+{time: 6/8}
+{tempo: 76}
+{capo: 0}
+
+{comment: Arpeggiated picking throughout}
+
+{start_of_verse: Verse 1}
+There [Am]is a [C]house in [D]New Or[F]leans
+They [Am]call the [C]Risin' [E7]Sun
+And it's [Am]been the [C]ruin of [D]many a poor [F]boy
+And [Am]God, I [E7]know I'm [Am]one
+{end_of_verse}
+
+{start_of_verse: Verse 2}
+My [Am]mother [C]was a [D]tail[F]or
+She [Am]sewed my [C]new blue [E7]jeans
+My [Am]father [C]was a [D]gamblin' [F]man
+[Am]Down in [E7]New Or[Am]leans
+{end_of_verse}

--- a/example/scarborough_fair.cho
+++ b/example/scarborough_fair.cho
@@ -1,0 +1,30 @@
+{title: Scarborough Fair}
+{artist: Traditional}
+{composer: Anonymous}
+{lyricist: Anonymous}
+{key: Em}
+{time: 3/4}
+{tempo: 96}
+{capo: 4}
+{x_difficulty: easy}
+
+{define: Em base-fret 1 frets 0 2 2 0 0 0}
+{define: D base-fret 1 frets x x 0 2 3 2}
+
+{start_of_verse: Verse 1}
+Are you [Em]going to [D]Scarborough [Em]Fair?
+[Em]Parsley, [G]sage, rose[A]mary and [Em]thyme
+Re[Em]member me to [G]one who lives [A]there
+For [Em]once she was a [D]true love of [Em]mine
+{end_of_verse}
+
+{start_of_chorus}
+[Em]Tell her to [D]make me a [Em]cambric shirt
+[Em]Parsley, [G]sage, rose[A]mary and [Em]thyme
+{end_of_chorus}
+
+{start_of_tab}
+e|--0--2--3--2--0--|
+B|--0--3--3--3--0--|
+G|--0--2--0--2--0--|
+{end_of_tab}

--- a/test/chord_pro_test.dart
+++ b/test/chord_pro_test.dart
@@ -49,5 +49,46 @@ void main() {
       expect(song.metadata.key, 'G');
       expect(song.metadata.tempo, 68);
     });
+
+    test('parses the House of the Rising Sun example', () {
+      final source =
+          File('example/house_of_the_rising_sun.cho').readAsStringSync();
+      final song = ChordPro.parseSong(source);
+      expect(song.metadata.titles.single, 'The House of the Rising Sun');
+      expect(song.metadata.subtitles, ['Traditional']);
+      expect(song.metadata.artists, ['The Animals']);
+      expect(song.metadata.key, 'Am');
+      expect(song.metadata.time, '6/8');
+      expect(song.metadata.tempo, 76);
+      expect(song.metadata.capo, 0);
+
+      final verses =
+          song.sections.where((s) => s.kind == SectionKind.verse).toList();
+      expect(verses, hasLength(2));
+      expect(verses.map((s) => s.label), ['Verse 1', 'Verse 2']);
+    });
+
+    test('parses the Scarborough Fair example', () {
+      final source = File('example/scarborough_fair.cho').readAsStringSync();
+      final song = ChordPro.parseSong(source);
+      expect(song.metadata.titles.single, 'Scarborough Fair');
+      expect(song.metadata.composers, ['Anonymous']);
+      expect(song.metadata.lyricists, ['Anonymous']);
+      expect(song.metadata.key, 'Em');
+      expect(song.metadata.time, '3/4');
+      expect(song.metadata.capo, 4);
+
+      expect(song.chordDefinitions.map((d) => d.name), ['Em', 'D']);
+
+      final kinds = song.sections.map((s) => s.kind).toList();
+      expect(kinds, contains(SectionKind.verse));
+      expect(kinds, contains(SectionKind.chorus));
+      expect(kinds, contains(SectionKind.tab));
+
+      expect(
+        song.customExtensions.map((d) => d.name),
+        ['x_difficulty'],
+      );
+    });
   });
 }


### PR DESCRIPTION
## Description

Adds two new ChordPro example fixtures and a parse test for each, broadening end-to-end coverage of real-song input beyond the single existing example.

- `example/house_of_the_rising_sun.cho` — exercises subtitle, time signature, capo, an in-flow `{comment}`, and two labeled verses.
- `example/scarborough_fair.cho` — exercises composer/lyricist, two `{define}` chord definitions, verse + chorus + tab sections, and an `x_*` custom-extension directive.
- `test/chord_pro_test.dart` — two new tests parse the fixtures and assert the metadata, sections, chord definitions, and custom extensions surface as expected.

No library code changes; tests pass via `very_good test`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)