### PR TITLE
chore: prepare for pub.dev publish (score 160/160)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,48 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Static analysis
+        run: dart analyze --fatal-infos
+
+      - name: Run tests with coverage
+        run: |
+          dart pub global activate coverage
+          dart pub global run coverage:test_with_coverage
+
+      - name: Enforce minimum coverage
+        run: |
+          dart pub global activate coverage
+          LCOV=coverage/lcov.info
+          test -f "$LCOV"
+          awk -F: '/^LF:/{lf+=$2} /^LH:/{lh+=$2} END{
+            if (lf == 0) { print "no coverage data"; exit 1 }
+            pct = 100 * lh / lf
+            printf "coverage: %.2f%% (%d/%d)\n", pct, lh, lf
+            if (pct < 85) { print "below 85% threshold"; exit 1 }
+          }' "$LCOV"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ pubspec.lock
 
 # Misc files
 .DS_Store
+
+# Coverage output
+coverage/

--- a/example/chord_pro_example.dart
+++ b/example/chord_pro_example.dart
@@ -1,0 +1,64 @@
+// Example file prints to stdout to demonstrate parser output.
+// ignore_for_file: avoid_print
+
+import 'package:chord_pro/chord_pro.dart';
+
+const _source = '''
+{title: Knockin' on Heaven's Door}
+{artist: Bob Dylan}
+{key: G}
+{tempo: 68}
+
+{start_of_verse: Verse 1}
+[G]Mama, take this [D]badge off of [Am]me
+[G]I can't use it [D]any[C]more
+{end_of_verse}
+
+{start_of_chorus}
+[G]Knock, knock, [D]knockin' on [Am]heaven's door
+{end_of_chorus}
+''';
+
+void main() {
+  // Parse a ChordPro document. Multi-song documents (split on {new_song})
+  // are returned in `result.songs`; diagnostics list any problems.
+  final result = ChordPro.parse(_source);
+  final song = result.songs.single;
+
+  print('Title:  ${song.metadata.titles.firstOrNull}');
+  print('Artist: ${song.metadata.artists.firstOrNull}');
+  print('Key:    ${song.metadata.key}');
+  print('Tempo:  ${song.metadata.tempo}');
+  print('Sections: ${song.sections.length}');
+
+  // Walk every section and print chords + lyrics.
+  for (final section in song.sections) {
+    print('\n[${section.kind.name}] ${section.label ?? ''}');
+    for (final line in section.lines) {
+      switch (line.kind) {
+        case LineKind.structured:
+          final buffer = StringBuffer();
+          for (final token in line.tokens) {
+            if (token is ChordToken) {
+              buffer.write('[${token.raw}]');
+            } else if (token is TextToken) {
+              buffer.write(token.text);
+            }
+          }
+          print('  $buffer');
+        case LineKind.comment:
+          print('  // ${line.comment}');
+        case LineKind.image:
+          print('  image: ${line.image?.src}');
+        case LineKind.layoutBreak:
+          print('  break: ${line.layoutBreak}');
+        case LineKind.verbatim:
+          print('  ${line.verbatim}');
+      }
+    }
+  }
+
+  // Transpose the whole song up two semitones.
+  final transposed = ChordPro.parseSong(_source).transposed(2);
+  print('\nTransposed key: ${transposed.metadata.key}');
+}

--- a/lib/chord_pro.dart
+++ b/lib/chord_pro.dart
@@ -1,3 +1,11 @@
+/// Parser for the [ChordPro 6 song format](https://www.chordpro.org/).
+///
+/// Use `ChordPro.parse` to parse a document into songs plus diagnostics,
+/// or `ChordPro.parseSong` to get the first song directly. Each `Song`
+/// exposes typed metadata, ordered sections of lines, parsed chord
+/// definitions, formatting settings and the raw directive stream.
+library;
+
 export 'src/ast/formatting.dart' show FormattingProps, FormattingSettings;
 export 'src/ast/line.dart' show CommentStyle, LayoutBreak, Line, LineKind;
 export 'src/ast/metadata.dart' show Metadata;
@@ -5,12 +13,16 @@ export 'src/ast/section.dart' show Section, SectionKind;
 export 'src/ast/song.dart' show Song;
 export 'src/chord/chord.dart'
     show AccidentalPreference, Chord, ChordSystem, transposeRoot;
-export 'src/chord/chord_definition.dart' show ChordDefinition;
+export 'src/chord/chord_definition.dart'
+    show ChordDefinition, parseChordDefinition;
 export 'src/chord_pro.dart' show ChordPro;
 export 'src/diagnostic/diagnostic.dart' show Diagnostic, DiagnosticSeverity;
 export 'src/diagnostic/parse_result.dart' show ParseResult;
 export 'src/directive/directive.dart' show Directive, Polarity;
-export 'src/directive/image_directive.dart' show ImageDirective;
+export 'src/directive/directive_parser.dart'
+    show DirectiveMatch, parseDirectiveAt, parseDirectiveLine;
+export 'src/directive/image_directive.dart'
+    show ImageDirective, parseImageDirective;
 export 'src/inline/inline_token.dart'
     show
         AnnotationToken,
@@ -19,4 +31,6 @@ export 'src/inline/inline_token.dart'
         InlineToken,
         TextToken;
 export 'src/inline/inline_tokenizer.dart' show tokenizeInline;
+export 'src/source/raw_line.dart' show RawLine;
+export 'src/source/scanner.dart' show scan;
 export 'src/source/source_span.dart' show SourceSpan;

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -215,8 +215,7 @@ ParseResult assemble(String source) {
             ),
           );
         }
-        open!.endSpan = directive.span;
-        final s = open!.finish();
+        final s = open!.finish(directive.span);
         if (s != null) sections.add(s);
         open = null;
         continue;
@@ -359,7 +358,6 @@ class _OpenSection {
   final String? customKind;
   final String? label;
   final SourceSpan startSpan;
-  SourceSpan? endSpan;
   final List<Line> _lines = [];
 
   bool get isVerbatim =>
@@ -402,7 +400,7 @@ class _OpenSection {
     _lines.add(Line.layoutBreak(layoutBreak: kind, span: span));
   }
 
-  Section? finish() {
+  Section? finish([SourceSpan? endSpan]) {
     if (kind == SectionKind.loose && _lines.isEmpty) return null;
     final end = endSpan ?? (_lines.isNotEmpty ? _lines.last.span : startSpan);
     return Section(

--- a/lib/src/ast/formatting.dart
+++ b/lib/src/ast/formatting.dart
@@ -66,8 +66,15 @@ const Map<String, String> _formattingAliases = {
 };
 
 /// Returns the formatting target + property when [name] is a known
-/// font/size/colour directive, or `null` otherwise. Both `colour` and
-/// the American `color` spelling are accepted on output.
+/// font/size/colour directive, or `null` otherwise.
+///
+/// The accepted target set is closed: `chord`, `chorus`, `footer`,
+/// `grid`, `tab`, `label`, `toc`, `text`, `title`. Names ending in
+/// `font` / `size` / `colour` / `color` for any other target are
+/// treated as unrelated directives and ignored — this avoids
+/// misinterpreting custom or future directives that happen to share a
+/// suffix. Both `colour` and the American `color` spelling are
+/// accepted on input; the returned property is always `colour`.
 ({String target, String property})? matchFormattingDirective(String name) {
   final canonical = _formattingAliases[name] ?? name;
   for (final suffix in const ['font', 'size', 'colour', 'color']) {
@@ -85,6 +92,11 @@ const Map<String, String> _formattingAliases = {
 }
 
 /// Reduces a stream of [Directive]s into a [FormattingSettings].
+///
+/// Only directives matching [matchFormattingDirective] (i.e. font/size/
+/// colour for the known target set) contribute; everything else is
+/// ignored without diagnostic since the same directive may carry
+/// meaning for another consumer.
 FormattingSettings reduceFormatting(Iterable<Directive> directives) {
   final byTarget = <String, FormattingProps>{};
   for (final d in directives) {

--- a/lib/src/ast/metadata.dart
+++ b/lib/src/ast/metadata.dart
@@ -250,13 +250,13 @@ Metadata reduceMetadata(
   }
 
   return Metadata(
-    titles: titles,
+    titles: List.unmodifiable(titles),
     sortTitle: sortTitle,
-    subtitles: subtitles,
-    artists: artists,
+    subtitles: List.unmodifiable(subtitles),
+    artists: List.unmodifiable(artists),
     sortArtist: sortArtist,
-    composers: composers,
-    lyricists: lyricists,
+    composers: List.unmodifiable(composers),
+    lyricists: List.unmodifiable(lyricists),
     copyright: copyright,
     album: album,
     year: year,
@@ -267,7 +267,12 @@ Metadata reduceMetadata(
     capo: capo,
     transpose: transpose,
     columns: columns,
-    tags: tags,
-    other: other,
+    tags: List.unmodifiable(tags),
+    other: Map.unmodifiable(
+      {
+        for (final e in other.entries)
+          e.key: List<String>.unmodifiable(e.value),
+      },
+    ),
   );
 }

--- a/lib/src/ast/song.dart
+++ b/lib/src/ast/song.dart
@@ -68,10 +68,7 @@ class Song {
         )
         .toList(growable: false);
 
-    final newKey = metadata.key == null
-        ? null
-        : transposeRoot(metadata.key!, semitones, accidentals: accidentals) ??
-            metadata.key;
+    final newKey = _transposeKey(metadata.key, semitones, accidentals);
 
     return Song(
       metadata: Metadata(
@@ -101,6 +98,23 @@ class Song {
       formatting: formatting,
     );
   }
+}
+
+/// Transposes a metadata key spelling.
+///
+/// Letter-system spellings (`G`, `Am`, `F#m7`) are remapped through the
+/// chromatic scale, preserving any quality/extension suffix. Unrecognised
+/// or non-letter spellings (e.g. Nashville/Roman keys, free text) are
+/// returned verbatim so callers don't lose the original value.
+String? _transposeKey(
+  String? key,
+  int semitones,
+  AccidentalPreference accidentals,
+) {
+  if (key == null) return null;
+  final chord = Chord.tryParse(key);
+  if (chord == null || chord.system != ChordSystem.letter) return key;
+  return chord.transpose(semitones, accidentals: accidentals).raw;
 }
 
 Line _transposeLine(

--- a/lib/src/chord/chord_definition.dart
+++ b/lib/src/chord/chord_definition.dart
@@ -35,6 +35,8 @@ class ChordDefinition {
   final SourceSpan span;
 }
 
+final RegExp _whitespace = RegExp(r'\s+');
+
 /// Parses a `{define}` / `{chord}` value body.
 ///
 /// Returns `null` when the body is empty or has no name. Unknown
@@ -43,8 +45,7 @@ ChordDefinition? parseChordDefinition(
   String value, {
   required SourceSpan span,
 }) {
-  final tokens =
-      value.split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
+  final tokens = value.split(_whitespace).where((t) => t.isNotEmpty).toList();
   if (tokens.isEmpty) return null;
 
   final name = tokens.first;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chord_pro
-description: Library for parsing chordpro song format
+description: A Dart parser for the ChordPro 6 song format. Extracts chords, lyrics, metadata, comments, layout hints and chord diagrams.
 version: 0.2.0
 repository: https://github.com/ryzizub/chord_pro
 

--- a/test/diagnostic/diagnostic_test.dart
+++ b/test/diagnostic/diagnostic_test.dart
@@ -1,0 +1,15 @@
+import 'package:chord_pro/chord_pro.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Diagnostic', () {
+    test('toString includes severity, span and message', () {
+      const diagnostic = Diagnostic(
+        severity: DiagnosticSeverity.warning,
+        message: 'unterminated chorus',
+        span: SourceSpan(line: 4, column: 1, length: 12),
+      );
+      expect(diagnostic.toString(), '[warning] 4:1+12: unterminated chorus');
+    });
+  });
+}

--- a/test/directive/directive_parser_test.dart
+++ b/test/directive/directive_parser_test.dart
@@ -1,6 +1,4 @@
-import 'package:chord_pro/src/directive/directive.dart';
-import 'package:chord_pro/src/directive/directive_parser.dart';
-import 'package:chord_pro/src/source/raw_line.dart';
+import 'package:chord_pro/chord_pro.dart';
 import 'package:test/test.dart';
 
 RawLine _line(String text) => RawLine(number: 1, text: text);

--- a/test/directive/directive_test.dart
+++ b/test/directive/directive_test.dart
@@ -1,0 +1,47 @@
+import 'package:chord_pro/chord_pro.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const span = SourceSpan(line: 1, column: 1, length: 1);
+
+  group('Directive', () {
+    test('toString renders bare directive', () {
+      const directive = Directive(name: 'new_song', span: span);
+      expect(directive.toString(), '{new_song}');
+    });
+
+    test('toString renders directive with value', () {
+      const directive = Directive(name: 'title', span: span, value: 'Demo');
+      expect(directive.toString(), '{title: Demo}');
+    });
+
+    test('toString renders positive selector', () {
+      const directive = Directive(
+        name: 'title',
+        span: span,
+        selector: 'guitar',
+        polarity: Polarity.positive,
+        value: 'Demo',
+      );
+      expect(directive.toString(), '{title-guitar: Demo}');
+    });
+
+    test('toString renders negative selector', () {
+      const directive = Directive(
+        name: 'title',
+        span: span,
+        selector: 'piano',
+        polarity: Polarity.negative,
+        value: 'Demo',
+      );
+      expect(directive.toString(), '{title+piano: Demo}');
+    });
+
+    test('isCustomExtension recognises x_* namespace', () {
+      const custom = Directive(name: 'x_my_tool', span: span);
+      const standard = Directive(name: 'title', span: span);
+      expect(custom.isCustomExtension, isTrue);
+      expect(standard.isCustomExtension, isFalse);
+    });
+  });
+}

--- a/test/directive/image_directive_test.dart
+++ b/test/directive/image_directive_test.dart
@@ -1,5 +1,4 @@
 import 'package:chord_pro/chord_pro.dart';
-import 'package:chord_pro/src/directive/image_directive.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/inline/inline_token_test.dart
+++ b/test/inline/inline_token_test.dart
@@ -1,0 +1,29 @@
+import 'package:chord_pro/chord_pro.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const span = SourceSpan(line: 1, column: 1, length: 1);
+
+  group('InlineToken.toString', () {
+    test('TextToken renders text', () {
+      const token = TextToken(text: 'hello', span: span);
+      expect(token.toString(), 'TextToken(hello)');
+    });
+
+    test('ChordToken renders raw', () {
+      const token = ChordToken(raw: 'G', chord: null, span: span);
+      expect(token.toString(), 'ChordToken(G)');
+    });
+
+    test('AnnotationToken renders annotation text', () {
+      const token = AnnotationToken(text: 'capo on 3', span: span);
+      expect(token.toString(), 'AnnotationToken(capo on 3)');
+    });
+
+    test('InlineDirectiveToken renders the directive', () {
+      const directive = Directive(name: 'comment', span: span, value: 'hey');
+      const token = InlineDirectiveToken(directive: directive, span: span);
+      expect(token.toString(), 'InlineDirectiveToken({comment: hey})');
+    });
+  });
+}

--- a/test/inline/inline_tokenizer_test.dart
+++ b/test/inline/inline_tokenizer_test.dart
@@ -1,5 +1,4 @@
 import 'package:chord_pro/chord_pro.dart';
-import 'package:chord_pro/src/source/raw_line.dart';
 import 'package:test/test.dart';
 
 RawLine _line(String text) => RawLine(number: 1, text: text);

--- a/test/source/scanner_test.dart
+++ b/test/source/scanner_test.dart
@@ -1,4 +1,4 @@
-import 'package:chord_pro/src/source/scanner.dart';
+import 'package:chord_pro/chord_pro.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/source/source_span_test.dart
+++ b/test/source/source_span_test.dart
@@ -1,0 +1,11 @@
+import 'package:chord_pro/chord_pro.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SourceSpan', () {
+    test('toString renders line:column+length', () {
+      const span = SourceSpan(line: 12, column: 4, length: 7);
+      expect(span.toString(), '12:4+7');
+    });
+  });
+}


### PR DESCRIPTION
## Description

Brings the package to a perfect 160/160 [pana](https://pub.dev/packages/pana) score so it's ready to publish to pub.dev, plus a follow-up refactor pass that tightens immutability and transposition behaviour.

**Score fixes** (commit 4cff9b7)
- Expand `pubspec.yaml` description to 123 chars (pana requires 50–180).
- Add a runnable Dart example at [example/chord_pro_example.dart](example/chord_pro_example.dart). Pana didn't recognise the existing `.cho` sample as an example — it now sits next to a real Dart entry point that exercises parsing, section walking, and transposition.
- Add a library-level dartdoc to [lib/chord_pro.dart](lib/chord_pro.dart) so 159/159 public symbols are documented.

**Public API surface** (commit 4cff9b7)
- Re-export `RawLine`, `scan`, `parseDirectiveAt` / `parseDirectiveLine` / `DirectiveMatch`, `parseChordDefinition`, and `parseImageDirective`.
- Hoist the whitespace regex in `parseChordDefinition` to a top-level constant now that it's part of the public API.

**Tooling** (commit 4cff9b7)
- New CI workflow ([.github/workflows/ci.yaml](.github/workflows/ci.yaml)) running format check, `dart analyze --fatal-infos`, tests with coverage, and an 85 % coverage gate.
- Ignore the generated `coverage/` directory.

**Refactor pass** (commit f16a247)
- `reduceMetadata` now wraps every list field and the `other` map (with its inner lists) in `List`/`Map.unmodifiable`, so the typed `Metadata` is genuinely immutable.
- `Song.transposed` replaces the silent `?? metadata.key` fallback with a `Chord.tryParse`-based helper, so compound keys (`Am`, `F#m7`, `Bbmaj7`) now remap through the chromatic scale instead of being preserved verbatim.
- Drop `_OpenSection`'s mutable `endSpan` field; `finish()` takes the end span as an optional positional parameter.
- Document `matchFormattingDirective`'s closed target set and `reduceFormatting`'s silent-ignore policy.
- Add `toString` coverage tests for `SourceSpan`, `Diagnostic`, `Directive`, and every `InlineToken` variant — those four files go from 22–38 % to 100 % line coverage. Total coverage 88.80 % → 91.57 %.
- Drop redundant `package:chord_pro/src/*` imports from existing tests now that the barrel re-exports them.

## Verification

- `pana 0.23.12` on Dart 3.11.4 → **160/160** across all five sections.
- `dart analyze` → 0 issues.
- `dart test` → all green.
- `dart run example/chord_pro_example.dart` → produces expected output.
- `dart pub publish --dry-run` → clean (only the expected uncommitted-changes warning, which clears once this lands).
- Coverage **91.57 %** (706/771), comfortably above the new 85 % CI gate.

## Notes for reviewer

- This is API-additive (new re-exports), so a follow-up `0.3.0` bump + CHANGELOG entry would be appropriate before publishing. The version is left at `0.2.0` so you can decide bump scope.
- The transposition change is a **semantics change**: keys like `Am` were previously preserved verbatim across `Song.transposed`; they now correctly transpose to `Em` (etc.). Existing tests pass; if any consumer relied on the old behaviour, this is the moment to call it out.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore