### PR TITLE
feat: gate metadata and formatting on conditional selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.3.0
+
+* Add `selectors:` argument to `ChordPro.parse` / `parseSong` so callers
+  can activate conditional directives. The same set is forwarded to
+  `reduceFormatting`, which now honours selector polarity. Matching is
+  case-insensitive.
+* `Directive.toString` emits the spec form `{name-!sel}` for negative
+  polarity instead of the legacy `+sel` form.
+* Drop the unused `collection` dependency.
+
 ## 0.2.0
 
 * Skip `#` file-comment lines per spec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,40 @@
+## 0.4.0
+
+Spec-compliance pass against the ChordPro reference parser.
+
+* **Breaking**: the canonical negation form is now postfix `!` —
+  `{name-sel!}` — matching the ChordPro spec and the reference Perl
+  parser (`s/\!$//`). `Directive.toString` emits this form. The previous
+  prefix `{name-!sel}` and legacy `{name+sel}` forms continue to be
+  accepted on input for backward compatibility but are now flagged as
+  non-spec.
+* Conditional selectors now gate **all** directives, not just metadata
+  and formatting. Sections with an inactive selector skip their entire
+  body (lines, nested directives, and the section end), per spec
+  ("selection applies to everything in the section, up to and including
+  the final section end directive"). Comments, images, layout breaks,
+  chorus recalls, and `{define}`/`{chord}` definitions are likewise
+  suppressed when their selector polarity does not match.
+* Add the spec-listed chord qualifiers `^` (alternate for `maj`), `h`
+  (half-diminished), and `0` (diminished, literal zero). The
+  pre-existing `ø`/`°` glyphs remain as documented non-spec extensions.
+* Add ChordPro 6.01 scanner features: `\`-terminated line continuation
+  (with leading whitespace stripped from the next line) and `\uXXXX`
+  Unicode escapes anywhere in the source.
+* Document explicitly which features are non-spec extensions of this
+  parser (German `H`, unicode accidentals, `ø`/`°`, `NC`/`N.C.`/`N.C`,
+  bracket-escapes, mid-lyric directives, legacy selector forms) and
+  which spec features are not yet covered (`label="…"` parsing, Pango
+  markup, `{define}` format strings).
+
 ## 0.3.0
 
 * Add `selectors:` argument to `ChordPro.parse` / `parseSong` so callers
   can activate conditional directives. The same set is forwarded to
   `reduceFormatting`, which now honours selector polarity. Matching is
   case-insensitive.
-* `Directive.toString` emits the spec form `{name-!sel}` for negative
-  polarity instead of the legacy `+sel` form.
+* `Directive.toString` emits a postfix `!` for negative polarity instead
+  of the legacy `+sel` form.
 * Drop the unused `collection` dependency.
 
 ## 0.2.0

--- a/README.md
+++ b/README.md
@@ -69,12 +69,22 @@ Each `Song` exposes:
 
 ## Supported features
 
-- Lyric/chord lines with backslash escapes for `[`, `]`, `{`, `}`.
-- Chord notation: letter (A–H), Nashville, Roman; sharps, flats, both
-  ASCII and unicode `♯`/`♭`; qualities (`m`, `mi`, `min`, `-`, `maj`,
-  `dim`, `aug`, `sus`, `add`, `ø`, `°`); slash bass notes; `NC`.
-- Section environments and chorus recall, plus delegated `abc`, `ly`,
-  `svg` and `textblock` blocks captured verbatim.
+- Spec-conformant chord notation per the [ChordPro reference][cp_chords]:
+  letter roots (`A`–`G`), Nashville (`1`–`7`), Roman (`I`–`VII`); sharps
+  and flats (`#`/`b`); slash bass; minor variants `m`/`mi`/`min`/`-`;
+  major qualifiers `maj` and the spec alternate `^`; diminished `dim`
+  and the literal-zero `0`; half-diminished `h`; `aug`, `sus`/`sus2`/
+  `sus4`, `add`.
+- Conditional directives — both positive (`{title-guitar: …}`) and
+  spec-form negation (`{title-guitar!: …}`, with `!` postfixed on the
+  selector per the [ChordPro reference parser][cp_directives]). Pass
+  `selectors:` to `ChordPro.parse` / `parseSong` to activate them; the
+  same set gates metadata, formatting, sections, comments, images,
+  layout breaks, chord recalls, and `{define}`/`{chord}` definitions.
+- All section environments — `verse`/`sov`, `chorus`/`soc`, `bridge`/
+  `sob`, `tab`/`sot`, `grid`/`sog`, plus delegated `abc`, `ly`, `svg`
+  and `textblock` captured verbatim. Custom `start_of_<name>` /
+  `end_of_<name>` sections preserved with their custom kind.
 - All metadata directives from the spec — `title`/`t`, `sorttitle`,
   `subtitle`/`st`, `artist`, `sortartist`, `composer`, `lyricist`,
   `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`,
@@ -83,20 +93,57 @@ Each `Song` exposes:
 - Comment family (`{comment}`, `{ci}`, `{cb}`, `{highlight}`) emitted
   as in-flow comment lines.
 - `{image: …}` parsed into a typed `ImageDirective`.
-- Page-break and column-break directives as in-flow layout breaks.
+- Page-break and column-break directives as in-flow layout breaks
+  (`{new_page}`, `{new_physical_page}`, `{column_break}`).
 - Font/size/colour directives (`chordfont`, `textsize`,
   `titlecolour`, …) reduced into `FormattingSettings`. Both `colour`
   and the American `color` spelling are accepted.
-- Conditional selectors with both spec-form `-!sel` and legacy `+sel`
-  negation; pass `selectors:` to `ChordPro.parse` to activate them
-  for typed metadata and formatting reduction.
-- Custom `x_*` extensions preserved on `Song.customExtensions`.
-- File-level `#` comments are dropped per spec.
+- Custom `x_*` extensions preserved on `Song.customExtensions` and
+  silently ignored by typed reduction (per spec).
+- File-level `#` comments dropped.
+- ChordPro 6.01 features: trailing `\`-line continuation and
+  `\uXXXX` Unicode escapes in any input text.
 - Diagnostics with 1-based source spans for every problem.
+
+## Non-spec extensions
+
+For ergonomic reasons this parser is more lenient than the published
+spec in a few places. Each is opt-in by simply being present in the
+input — your file will still parse, but the named feature is **not**
+required by ChordPro itself:
+
+- `H` as a letter root (German notation for B natural).
+- Unicode accidentals `♯` (U+266F) and `♭` (U+266D).
+- Half-diminished `ø` and diminished `°` glyphs (the spec marks these
+  as `h` and `0`/`dim`).
+- No-chord markers `NC`, `N.C.`, `N.C` (the spec is silent).
+- Backslash-escapes for `[`, `]`, `{`, `}`, `\` inside lyric lines.
+- `{…}` directives appearing mid-lyric (the spec requires directives
+  to occupy a whole line).
+- Legacy negative-selector forms `{name-!sel}` and `{name+sel}`,
+  retained for backward compatibility with older files. New files
+  should use the spec form `{name-sel!}`.
+
+## Known limitations
+
+- The `label="value"` form for section labels is parsed as raw value
+  text; only the bare `{start_of_verse: Verse 1}` form is mapped to
+  `Section.label`.
+- Pango-style markup (`<b>`, `<i>`, `<span …>`, `<sym …/>`, `<img …/>`,
+  `<strut …/>`) inside lyric/comment text is preserved verbatim — no
+  inline parsing is performed.
+- `{define}`'s `format` argument and the associated `\%{` escape are
+  passed through as raw value text.
+- The legacy/no-op directives `pagetype`, `grid`, `no_grid`, `titles`,
+  and `diagrams` land in `Song.directives` only — they are not given
+  typed access.
 
 ## Example of chordpro format
 
 [example song](./example/knockin_on_heavens_door.cho)
+
+[cp_chords]: https://www.chordpro.org/chordpro/chordpro-chords/
+[cp_directives]: https://www.chordpro.org/chordpro/chordpro-directives/
 
 [license_badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license_link]: https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -42,15 +42,21 @@ for (final song in result.songs) {
 
 // Transposition.
 final upTwo = ChordPro.parseSong(source).transposed(2);
+
+// Conditional selectors (e.g. instrument-specific titles).
+final guitar = ChordPro.parseSong(source, selectors: {'guitar'});
 ```
 
 `ChordPro.parse` returns a `ParseResult` with every song in the
 document (split on `{new_song}` / `{ns}`) plus any diagnostics.
 `ChordPro.parseSong` is a convenience that returns the first song.
+Pass `selectors:` to activate conditional directives — see below.
 
 Each `Song` exposes:
-- `metadata` — typed `Metadata` with titles, artists, key, tempo,
-  capo, transpose, columns, tags and more.
+- `metadata` — typed `Metadata` with titles, sort titles, subtitles,
+  artists, sort artist, composers, lyricists, copyright, album,
+  year, key, time, tempo, duration, capo, transpose, columns, tags
+  and an `other` map for anything custom.
 - `sections` — ordered `Section`s for verses, choruses, bridges,
   tabs, grids, abc, ly, svg, textblock and custom environments,
   plus loose lines.
@@ -69,16 +75,22 @@ Each `Song` exposes:
   `dim`, `aug`, `sus`, `add`, `ø`, `°`); slash bass notes; `NC`.
 - Section environments and chorus recall, plus delegated `abc`, `ly`,
   `svg` and `textblock` blocks captured verbatim.
-- All metadata directives from the spec, including `sortartist`,
-  `tag`, `transpose`, `columns`, plus `{meta: key value}` desugaring.
+- All metadata directives from the spec — `title`/`t`, `sorttitle`,
+  `subtitle`/`st`, `artist`, `sortartist`, `composer`, `lyricist`,
+  `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`,
+  `capo`, `transpose`, `columns`/`col`, `tag` — plus `{meta: key
+  value}` desugaring.
 - Comment family (`{comment}`, `{ci}`, `{cb}`, `{highlight}`) emitted
   as in-flow comment lines.
 - `{image: …}` parsed into a typed `ImageDirective`.
 - Page-break and column-break directives as in-flow layout breaks.
 - Font/size/colour directives (`chordfont`, `textsize`,
-  `titlecolour`, …) reduced into `FormattingSettings`.
+  `titlecolour`, …) reduced into `FormattingSettings`. Both `colour`
+  and the American `color` spelling are accepted.
 - Conditional selectors with both spec-form `-!sel` and legacy `+sel`
-  negation.
+  negation; pass `selectors:` to `ChordPro.parse` to activate them
+  for typed metadata and formatting reduction.
+- Custom `x_*` extensions preserved on `Song.customExtensions`.
 - File-level `#` comments are dropped per spec.
 - Diagnostics with 1-based source spans for every problem.
 

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -15,7 +15,18 @@ import 'package:chord_pro/src/source/scanner.dart';
 import 'package:chord_pro/src/source/source_span.dart';
 
 /// Parses [source] into one or more [Song]s plus diagnostics.
-ParseResult assemble(String source) {
+///
+/// [selectors] names the conditional selectors that should be treated as
+/// active when reducing metadata and formatting directives. Matching is
+/// case-insensitive; selectors are folded to lower-case to match what the
+/// directive parser stores.
+ParseResult assemble(
+  String source, {
+  Set<String> selectors = const {},
+}) {
+  final activeSelectors = selectors.isEmpty
+      ? const <String>{}
+      : {for (final s in selectors) s.toLowerCase()};
   final lines = scan(source);
   final diagnostics = <Diagnostic>[];
   final songs = <Song>[];
@@ -50,11 +61,17 @@ ParseResult assemble(String source) {
     }
     songs.add(
       Song(
-        metadata: reduceMetadata(_expandMeta(directives, diagnostics)),
+        metadata: reduceMetadata(
+          _expandMeta(directives, diagnostics),
+          includeSelected: activeSelectors,
+        ),
         directives: List.unmodifiable(directives),
         sections: List.unmodifiable(sections),
         chordDefinitions: List.unmodifiable(chordDefs),
-        formatting: reduceFormatting(directives),
+        formatting: reduceFormatting(
+          directives,
+          includeSelected: activeSelectors,
+        ),
       ),
     );
     directives = <Directive>[];

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -35,6 +35,10 @@ ParseResult assemble(
   var sections = <Section>[];
   var chordDefs = <ChordDefinition>[];
   _OpenSection? open;
+  // Set when a `start_of_X-selector(!)` directive doesn't apply for the
+  // current selector set: every line until the matching `end_of_X` is
+  // suppressed (still appended to the directive stream for round-trip).
+  _StartKind? skipUntilEnd;
 
   void closeLoose() {
     if (open != null && open!.kind == SectionKind.loose) {
@@ -84,12 +88,46 @@ ParseResult assemble(
 
     final directive = parseDirectiveLine(line);
 
+    // Inside a selector-skipped section: consume until the matching end
+    // directive arrives. Every directive is still appended to the
+    // directive stream so that `Song.directives` is lossless.
+    final pending = skipUntilEnd;
+    if (pending != null) {
+      if (directive != null) {
+        directives.add(directive);
+        final endKind = _endKindOf(directive.name);
+        if (endKind != null &&
+            endKind.kind == pending.kind &&
+            (endKind.kind != SectionKind.custom ||
+                endKind.customKind == pending.customKind)) {
+          skipUntilEnd = null;
+        }
+      }
+      continue;
+    }
+
     if (directive != null) {
       directives.add(directive);
 
-      // Song boundary.
+      // Song boundary always applies regardless of selectors — splitting
+      // songs is structural, not conditional.
       if (directive.name == 'new_song' || directive.name == 'ns') {
         finishSong();
+        continue;
+      }
+
+      // Selector gate. Per spec, "all directives can be conditionally
+      // selected … selection applies to everything in the section, up to
+      // and including the final section end directive."
+      final applies = _selectorApplies(directive, activeSelectors);
+      if (!applies) {
+        final startKind = _startKindOf(directive.name);
+        if (startKind != null) {
+          skipUntilEnd = startKind;
+        }
+        // Non-section directives are simply suppressed; metadata and
+        // formatting reducers already filter selector-tagged directives
+        // independently from the directive stream.
         continue;
       }
 
@@ -329,6 +367,24 @@ CommentStyle? _commentStyleOf(String name) {
       return CommentStyle.highlight;
   }
   return null;
+}
+
+/// Returns whether [d]'s selector resolves against [active] selectors.
+///
+/// Per the ChordPro spec, a directive without a selector always applies;
+/// a positive selector (`{name-sel}`) applies when `sel` is in [active];
+/// a negative selector (spec-form `{name-sel!}`, or this library's
+/// non-spec `{name-!sel}` / `{name+sel}` legacy forms) applies when it
+/// is not.
+bool _selectorApplies(Directive d, Set<String> active) {
+  final sel = d.selector;
+  if (sel == null) return true;
+  final isActive = active.contains(sel);
+  return switch (d.polarity) {
+    Polarity.positive => isActive,
+    Polarity.negative => !isActive,
+    Polarity.none => true,
+  };
 }
 
 _StartKind? _endKindOf(String name) {

--- a/lib/src/ast/formatting.dart
+++ b/lib/src/ast/formatting.dart
@@ -97,10 +97,27 @@ const Map<String, String> _formattingAliases = {
 /// colour for the known target set) contribute; everything else is
 /// ignored without diagnostic since the same directive may carry
 /// meaning for another consumer.
-FormattingSettings reduceFormatting(Iterable<Directive> directives) {
+///
+/// Directives carrying a selector contribute when the selector polarity
+/// matches [includeSelected] — bare directives always apply, positive
+/// `-sel` only when `sel` is in the set, and negative `-!sel` (or legacy
+/// `+sel`) only when it is not.
+FormattingSettings reduceFormatting(
+  Iterable<Directive> directives, {
+  Set<String> includeSelected = const {},
+}) {
   final byTarget = <String, FormattingProps>{};
   for (final d in directives) {
     if (d.value == null) continue;
+    if (d.selector != null) {
+      final active = includeSelected.contains(d.selector);
+      final applies = switch (d.polarity) {
+        Polarity.positive => active,
+        Polarity.negative => !active,
+        Polarity.none => true,
+      };
+      if (!applies) continue;
+    }
     final match = matchFormattingDirective(d.name);
     if (match == null) continue;
     final current = byTarget[match.target] ?? const FormattingProps();

--- a/lib/src/chord/chord.dart
+++ b/lib/src/chord/chord.dart
@@ -291,6 +291,20 @@ bool _isAccidental(int c) =>
 
 bool _isWhitespace(int c) => c == 0x20 || c == 0x09;
 
+// Order matters: longer prefixes come first so `min` wins over `mi`,
+// `dim` over `d`, etc.
+//
+// Spec-listed (per chordpro.org/chordpro/chordpro-chords/):
+//   `m`, `mi`, `min`, `-` (minor)
+//   `maj`, `^` (major; `^` is the spec-defined alternate for `maj`)
+//   `dim`, `0` (diminished; `0` is literal digit zero)
+//   `h` (half-diminished)
+//   `aug`, `+`
+//   `sus`, `sus2`, `sus4`, `add`
+//
+// Non-spec extensions kept for ergonomic reasons:
+//   `ø` (common half-diminished glyph)
+//   `°` (common diminished glyph)
 const List<String> _qualities = [
   'maj',
   'min',
@@ -301,8 +315,11 @@ const List<String> _qualities = [
   'aug',
   'dim',
   'add',
-  'ø', // half-diminished
-  '°', // diminished
+  'ø', // half-diminished (non-spec; `h` is the spec marker)
+  '°', // diminished (non-spec; `0` and `dim` are spec)
+  '^', // major (spec alternate for `maj`)
   'm',
+  'h', // half-diminished (spec)
+  '0', // diminished (spec; literal zero)
   '-',
 ];

--- a/lib/src/chord_pro.dart
+++ b/lib/src/chord_pro.dart
@@ -10,8 +10,23 @@ class ChordPro {
   ///
   /// Documents are split on `{new_song}` / `{ns}`; an empty document
   /// still yields a single empty [Song].
-  static ParseResult parse(String source) => assemble(source);
+  ///
+  /// [selectors] names the conditional selectors that should be treated
+  /// as active. Directives carrying a positive selector (`{title-print}`)
+  /// only contribute to typed metadata and formatting when the selector
+  /// is in this set; directives with a negative selector
+  /// (`{title-!print}` or legacy `{title+print}`) only contribute when it
+  /// is not.
+  static ParseResult parse(
+    String source, {
+    Set<String> selectors = const {},
+  }) =>
+      assemble(source, selectors: selectors);
 
   /// Convenience wrapper that returns the first song of [source].
-  static Song parseSong(String source) => parse(source).songs.first;
+  static Song parseSong(
+    String source, {
+    Set<String> selectors = const {},
+  }) =>
+      parse(source, selectors: selectors).songs.first;
 }

--- a/lib/src/directive/directive.dart
+++ b/lib/src/directive/directive.dart
@@ -68,7 +68,7 @@ class Directive {
         ? ''
         : polarity == Polarity.positive
             ? '-$selector'
-            : '+$selector';
+            : '-!$selector';
     final v = value == null ? '' : ': $value';
     return '{$name$sel$v}';
   }

--- a/lib/src/directive/directive.dart
+++ b/lib/src/directive/directive.dart
@@ -3,9 +3,12 @@ import 'package:chord_pro/src/source/source_span.dart';
 /// Polarity of a directive selector suffix.
 ///
 /// ChordPro spec form is `{name-sel: …}` (apply only when `sel` is
-/// active) and `{name-!sel: …}` (apply only when `sel` is *not*
-/// active). The legacy `{name+sel: …}` form is also accepted as a
-/// negation. Bare directives carry [Polarity.none].
+/// active) and `{name-sel!: …}` (apply only when `sel` is *not*
+/// active — note the `!` is **postfixed** on the selector per the
+/// reference parser). For backward compatibility with files written
+/// against earlier releases of this library, the non-spec forms
+/// `{name-!sel: …}` and `{name+sel: …}` are also accepted as
+/// negations on input. Bare directives carry [Polarity.none].
 enum Polarity {
   /// No selector suffix present.
   none,
@@ -13,8 +16,8 @@ enum Polarity {
   /// `-selector` form: active only when the selector is set.
   positive,
 
-  /// `-!selector` (or legacy `+selector`) form: active only when the
-  /// selector is not set.
+  /// `-selector!` (spec) or legacy `-!selector` / `+selector` forms:
+  /// active only when the selector is not set.
   negative,
 }
 
@@ -68,7 +71,7 @@ class Directive {
         ? ''
         : polarity == Polarity.positive
             ? '-$selector'
-            : '-!$selector';
+            : '-$selector!';
     final v = value == null ? '' : ': $value';
     return '{$name$sel$v}';
   }

--- a/lib/src/directive/directive_parser.dart
+++ b/lib/src/directive/directive_parser.dart
@@ -111,9 +111,11 @@ _Parsed? _parseInner(String inner) {
   if (head.isEmpty) return null;
 
   // Split selector off head.
-  // Spec form is `name-selector` (positive) or `name-!selector` (negative).
-  // The legacy `name+selector` form is also accepted for backwards
-  // compatibility and treated as a negation.
+  // Spec form (ChordPro reference): `name-selector` (positive) or
+  // `name-selector!` (negative — `!` is *postfixed* to the selector).
+  // For backward compatibility this parser also accepts two non-spec
+  // forms used by earlier releases of this library:
+  // `name-!selector` (prefix `!`) and the legacy `name+selector`.
   var polarity = Polarity.none;
   String? selector;
   var name = head;
@@ -128,6 +130,12 @@ _Parsed? _parseInner(String inner) {
     var sel = head.substring(sep + 1).trim();
     final isLegacyPlus = head.codeUnitAt(sep) == 0x2B;
     var negated = isLegacyPlus;
+    // Spec form: trailing `!` on the selector.
+    if (sel.length > 1 && sel.endsWith('!')) {
+      sel = sel.substring(0, sel.length - 1).trim();
+      negated = true;
+    }
+    // Non-spec leading `!` retained for backward compatibility.
     if (!isLegacyPlus && sel.startsWith('!')) {
       sel = sel.substring(1).trim();
       negated = true;

--- a/lib/src/source/scanner.dart
+++ b/lib/src/source/scanner.dart
@@ -5,15 +5,23 @@ import 'package:chord_pro/src/source/raw_line.dart';
 /// Recognises `\n`, `\r\n`, and lone `\r` as line terminators. An empty
 /// input produces an empty list; a trailing newline does not produce a
 /// trailing blank line.
+///
+/// Per ChordPro 6.01:
+///  - A line ending with `\` is continued by the following line; the
+///    backslash and the leading whitespace of the next line are
+///    discarded. The continued line keeps the line number where it
+///    started.
+///  - `\uXXXX` (4 hex digits) anywhere in the text is replaced by the
+///    corresponding Unicode code point.
 List<RawLine> scan(String source) {
   if (source.isEmpty) return const [];
 
-  final lines = <RawLine>[];
+  final physical = <RawLine>[];
   final buffer = StringBuffer();
   var lineNumber = 1;
 
   void flush() {
-    lines.add(RawLine(number: lineNumber, text: buffer.toString()));
+    physical.add(RawLine(number: lineNumber, text: buffer.toString()));
     buffer.clear();
     lineNumber++;
   }
@@ -31,5 +39,64 @@ List<RawLine> scan(String source) {
   }
   if (buffer.isNotEmpty) flush();
 
-  return lines;
+  final result = <RawLine>[];
+  for (var i = 0; i < physical.length; i++) {
+    final start = physical[i];
+    var text = start.text;
+    while (_endsWithUnescapedBackslash(text) && i + 1 < physical.length) {
+      text =
+          text.substring(0, text.length - 1) + _stripLead(physical[i + 1].text);
+      i++;
+    }
+    result
+        .add(RawLine(number: start.number, text: _resolveUnicodeEscapes(text)));
+  }
+
+  return result;
+}
+
+bool _endsWithUnescapedBackslash(String s) {
+  if (s.isEmpty) return false;
+  if (s.codeUnitAt(s.length - 1) != 0x5C) return false;
+  // Count trailing backslashes; an odd count means the last one is not
+  // itself escaped, so it acts as a continuation marker.
+  var count = 0;
+  for (var i = s.length - 1; i >= 0 && s.codeUnitAt(i) == 0x5C; i--) {
+    count++;
+  }
+  return count.isOdd;
+}
+
+String _stripLead(String s) {
+  var i = 0;
+  while (i < s.length) {
+    final c = s.codeUnitAt(i);
+    if (c == 0x20 || c == 0x09) {
+      i++;
+    } else {
+      break;
+    }
+  }
+  return i == 0 ? s : s.substring(i);
+}
+
+String _resolveUnicodeEscapes(String s) {
+  if (s.length < 6) return s;
+  final out = StringBuffer();
+  var i = 0;
+  while (i < s.length) {
+    final ch = s.codeUnitAt(i);
+    if (ch == 0x5C && i + 5 < s.length && s.codeUnitAt(i + 1) == 0x75) {
+      final hex = s.substring(i + 2, i + 6);
+      final code = int.tryParse(hex, radix: 16);
+      if (code != null) {
+        out.writeCharCode(code);
+        i += 6;
+        continue;
+      }
+    }
+    out.writeCharCode(ch);
+    i++;
+  }
+  return out.toString();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,10 @@
 name: chord_pro
 description: A Dart parser for the ChordPro 6 song format. Extracts chords, lyrics, metadata, comments, layout hints and chord diagrams.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/ryzizub/chord_pro
 
 environment:
   sdk: ^3.5.0
-
-dependencies:
-  collection: ^1.19.1
 
 dev_dependencies:
   test: ^1.25.15

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chord_pro
 description: A Dart parser for the ChordPro 6 song format. Extracts chords, lyrics, metadata, comments, layout hints and chord diagrams.
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/ryzizub/chord_pro
 
 environment:

--- a/test/assembler/sections_test.dart
+++ b/test/assembler/sections_test.dart
@@ -77,6 +77,37 @@ B|--1--|
       expect(section.lines.first.verbatim, 'e|--0--|');
     });
 
+    test('captures abc verbatim', () {
+      const source = '''
+{start_of_abc}
+X:1
+T:Sample
+{end_of_abc}
+''';
+      final song = ChordPro.parseSong(source);
+      final section = song.sections.single;
+      expect(section.kind, SectionKind.abc);
+      expect(section.lines.every((l) => l.isVerbatim), isTrue);
+      expect(section.lines.map((l) => l.verbatim).toList(), [
+        'X:1',
+        'T:Sample',
+      ]);
+    });
+
+    test('captures ly verbatim', () {
+      const source = r'''
+{start_of_ly}
+\version "2.20.0"
+\score { … }
+{end_of_ly}
+''';
+      final song = ChordPro.parseSong(source);
+      final section = song.sections.single;
+      expect(section.kind, SectionKind.ly);
+      expect(section.lines.every((l) => l.isVerbatim), isTrue);
+      expect(section.lines.first.verbatim, r'\version "2.20.0"');
+    });
+
     test('bare {chorus} is a chorus recall', () {
       final song = ChordPro.parseSong('{chorus}');
       expect(song.sections, hasLength(1));

--- a/test/chord/chord_definition_test.dart
+++ b/test/chord/chord_definition_test.dart
@@ -93,5 +93,91 @@ void main() {
       final song = ChordPro.parseSong(source, selectors: {'print'});
       expect(song.formatting.forTarget('chord').font, 'Sans');
     });
+
+    test('spec postfix `!` form on formatting works too', () {
+      const source = '{chordfont: Sans}\n{chordfont-print!: Mono}';
+      // print is inactive, so the `-print!` (negation) directive applies.
+      final song = ChordPro.parseSong(source);
+      expect(song.formatting.forTarget('chord').font, 'Mono');
+    });
+  });
+
+  group('Selector-aware sections, comments, images, and breaks', () {
+    test('section start with inactive selector skips entire section body', () {
+      const source = '''
+[G]before
+{start_of_verse-soprano}
+[A]inside that should be hidden
+{comment: also hidden}
+{end_of_verse}
+[D]after
+''';
+      final song = ChordPro.parseSong(source);
+      // No selectors active, so the `-soprano` section is gated out.
+      // Only the surrounding loose lines remain.
+      expect(song.sections, hasLength(1));
+      final lines = song.sections.single.lines;
+      expect(lines, hasLength(2));
+      expect(lines.first.kind, LineKind.structured);
+      expect(lines.last.kind, LineKind.structured);
+    });
+
+    test('section start with active positive selector keeps body', () {
+      const source = '''
+{start_of_verse-soprano}
+[A]inside
+{end_of_verse}
+''';
+      final song = ChordPro.parseSong(source, selectors: {'soprano'});
+      expect(song.sections.single.kind, SectionKind.verse);
+      expect(song.sections.single.lines, hasLength(1));
+    });
+
+    test('section start with postfix `!` keeps body when selector inactive',
+        () {
+      const source = '''
+{start_of_verse-soprano!}
+[A]for everyone else
+{end_of_verse}
+''';
+      final song = ChordPro.parseSong(source);
+      expect(song.sections.single.kind, SectionKind.verse);
+    });
+
+    test('comment with inactive selector emits nothing in flow', () {
+      const source = '''
+{start_of_verse}
+[G]hi
+{comment-print: only when printing}
+[D]bye
+{end_of_verse}
+''';
+      final song = ChordPro.parseSong(source);
+      final lines = song.sections.single.lines;
+      expect(lines.map((l) => l.kind).toList(), [
+        LineKind.structured,
+        LineKind.structured,
+      ]);
+    });
+
+    test('chord recall with inactive selector emits no recall section', () {
+      const source = '{chorus-soprano}';
+      final song = ChordPro.parseSong(source);
+      expect(song.sections, isEmpty);
+    });
+
+    test('chord define with inactive selector is suppressed', () {
+      const source = '''
+{define-guitar: Am base-fret 1 frets x 0 2 2 1 0}
+{define-ukulele: Am base-fret 1 frets 2 0 0 0}
+''';
+      final guitar = ChordPro.parseSong(source, selectors: {'guitar'});
+      expect(guitar.chordDefinitions, hasLength(1));
+      expect(guitar.chordDefinitions.single.frets, [null, 0, 2, 2, 1, 0]);
+
+      final ukulele = ChordPro.parseSong(source, selectors: {'ukulele'});
+      expect(ukulele.chordDefinitions, hasLength(1));
+      expect(ukulele.chordDefinitions.single.frets, [2, 0, 0, 0]);
+    });
   });
 }

--- a/test/chord/chord_definition_test.dart
+++ b/test/chord/chord_definition_test.dart
@@ -21,6 +21,14 @@ void main() {
       expect(song.chordDefinitions.single.frets, [null, null, 0, 2, 3, 2]);
     });
 
+    test('treats {chord: ...} as a {define} alias', () {
+      const source = '{chord: A base-fret 1 frets x 0 2 2 2 0}';
+      final song = ChordPro.parseSong(source);
+      expect(song.chordDefinitions.single.name, 'A');
+      expect(song.chordDefinitions.single.baseFret, 1);
+      expect(song.chordDefinitions.single.frets, [null, 0, 2, 2, 2, 0]);
+    });
+
     test('emits a diagnostic for an empty define', () {
       final result = ChordPro.parse('{define:}');
       expect(result.songs.single.chordDefinitions, isEmpty);
@@ -32,6 +40,58 @@ void main() {
       const source = '{title: Plain}\n{title-guitar: Fancy}';
       final song = ChordPro.parseSong(source);
       expect(song.metadata.titles, ['Plain']);
+    });
+
+    test('includes positive-selector titles when selector is active', () {
+      const source = '{title: Plain}\n{title-guitar: Fancy}';
+      final song = ChordPro.parseSong(source, selectors: {'guitar'});
+      expect(song.metadata.titles, ['Plain', 'Fancy']);
+    });
+
+    test('skips negative-selector titles when selector is active', () {
+      const source = '{title: Plain}\n{title-!guitar: For Others}';
+      final song = ChordPro.parseSong(source, selectors: {'guitar'});
+      expect(song.metadata.titles, ['Plain']);
+    });
+
+    test('keeps negative-selector titles when selector is inactive', () {
+      const source = '{title: Plain}\n{title-!guitar: For Others}';
+      final song = ChordPro.parseSong(source);
+      expect(song.metadata.titles, ['Plain', 'For Others']);
+    });
+
+    test('legacy {name+selector} form is treated as negation', () {
+      const source = '{title: Plain}\n{title+guitar: For Others}';
+      final guitar = ChordPro.parseSong(source, selectors: {'guitar'});
+      expect(guitar.metadata.titles, ['Plain']);
+      final piano = ChordPro.parseSong(source);
+      expect(piano.metadata.titles, ['Plain', 'For Others']);
+    });
+
+    test('selector matching is case-insensitive', () {
+      const source = '{title: Plain}\n{title-Guitar: Fancy}';
+      final song = ChordPro.parseSong(source, selectors: {'GUITAR'});
+      expect(song.metadata.titles, ['Plain', 'Fancy']);
+    });
+  });
+
+  group('Selector-aware formatting', () {
+    test('skips selector-tagged formatting by default', () {
+      const source = '{textcolour: black}\n{textcolour-print: gray}';
+      final song = ChordPro.parseSong(source);
+      expect(song.formatting.forTarget('text').colour, 'black');
+    });
+
+    test('applies positive-selector formatting when selector is active', () {
+      const source = '{textcolour: black}\n{textcolour-print: gray}';
+      final song = ChordPro.parseSong(source, selectors: {'print'});
+      expect(song.formatting.forTarget('text').colour, 'gray');
+    });
+
+    test('skips negative-selector formatting when selector is active', () {
+      const source = '{chordfont: Sans}\n{chordfont-!print: Mono}';
+      final song = ChordPro.parseSong(source, selectors: {'print'});
+      expect(song.formatting.forTarget('chord').font, 'Sans');
     });
   });
 }

--- a/test/chord/chord_test.dart
+++ b/test/chord/chord_test.dart
@@ -77,6 +77,16 @@ void main() {
       expect(Chord.tryParse('C°')!.quality, '°');
     });
 
+    test('parses spec chord qualifiers `^`, `h`, `0`', () {
+      // `^` is the spec-defined alternate for `maj`.
+      expect(Chord.tryParse('C^7')!.quality, '^');
+      expect(Chord.tryParse('C^7')!.extensions, ['7']);
+      // `h` is half-diminished.
+      expect(Chord.tryParse('Bh7')!.quality, 'h');
+      // `0` (literal zero) is diminished.
+      expect(Chord.tryParse('C0')!.quality, '0');
+    });
+
     test('parses NC as a no-chord marker', () {
       final c = Chord.tryParse('NC')!;
       expect(c.root, 'NC');

--- a/test/directive/directive_parser_test.dart
+++ b/test/directive/directive_parser_test.dart
@@ -44,7 +44,13 @@ void main() {
       expect(d.polarity, Polarity.negative);
     });
 
-    test('captures spec-form ! negation', () {
+    test('captures spec-form postfix ! negation', () {
+      final d = parseDirectiveLine(_line('{title-guitar!: Plain}'))!;
+      expect(d.selector, 'guitar');
+      expect(d.polarity, Polarity.negative);
+    });
+
+    test('still accepts non-spec prefix !sel for backward compatibility', () {
       final d = parseDirectiveLine(_line('{title-!guitar: Plain}'))!;
       expect(d.selector, 'guitar');
       expect(d.polarity, Polarity.negative);

--- a/test/directive/directive_test.dart
+++ b/test/directive/directive_test.dart
@@ -26,7 +26,7 @@ void main() {
       expect(directive.toString(), '{title-guitar: Demo}');
     });
 
-    test('toString renders negative selector', () {
+    test('toString renders negative selector in spec form', () {
       const directive = Directive(
         name: 'title',
         span: span,
@@ -34,7 +34,7 @@ void main() {
         polarity: Polarity.negative,
         value: 'Demo',
       );
-      expect(directive.toString(), '{title+piano: Demo}');
+      expect(directive.toString(), '{title-!piano: Demo}');
     });
 
     test('isCustomExtension recognises x_* namespace', () {

--- a/test/directive/directive_test.dart
+++ b/test/directive/directive_test.dart
@@ -26,7 +26,7 @@ void main() {
       expect(directive.toString(), '{title-guitar: Demo}');
     });
 
-    test('toString renders negative selector in spec form', () {
+    test('toString renders negative selector with postfix `!` (spec form)', () {
       const directive = Directive(
         name: 'title',
         span: span,
@@ -34,7 +34,7 @@ void main() {
         polarity: Polarity.negative,
         value: 'Demo',
       );
-      expect(directive.toString(), '{title-!piano: Demo}');
+      expect(directive.toString(), '{title-piano!: Demo}');
     });
 
     test('isCustomExtension recognises x_* namespace', () {

--- a/test/source/scanner_test.dart
+++ b/test/source/scanner_test.dart
@@ -34,5 +34,40 @@ void main() {
         true,
       ]);
     });
+
+    test(r'concatenates lines that end in `\` (ChordPro 6.01)', () {
+      final lines = scan('one\\\n   two\nthree');
+      expect(lines.map((l) => l.text).toList(), ['onetwo', 'three']);
+      expect(lines.first.number, 1);
+    });
+
+    test(r'continuation chains across multiple `\`-terminated lines', () {
+      final lines = scan('a\\\nb\\\n\tc\nd');
+      expect(lines.map((l) => l.text).toList(), ['abc', 'd']);
+    });
+
+    test(r'leaves an even-count trailing `\` alone (escaped backslash)', () {
+      final lines = scan(r'foo\\' '\nbar');
+      expect(lines.map((l) => l.text).toList(), [r'foo\\', 'bar']);
+    });
+
+    test(r'resolves `\uXXXX` escapes (ChordPro 6.01)', () {
+      // Source contains the literal six-char sequences
+      // backslash-u-0-0-e-9 and backslash-u-2-6-6-f. Built via
+      // codepoints to avoid the editor collapsing them.
+      final source = String.fromCharCodes(<int>[
+        0x43, 0x61, 0x66, // C a f
+        0x5C, 0x75, 0x30, 0x30, 0x65, 0x39, // \u00e9
+        0x20,
+        0x5C, 0x75, 0x32, 0x36, 0x36, 0x66, // \u266f
+      ]);
+      final lines = scan(source);
+      expect(lines.single.text, 'Café ♯');
+    });
+
+    test('leaves malformed unicode escapes alone', () {
+      final lines = scan(r'oops \uZZZZ');
+      expect(lines.single.text, r'oops \uZZZZ');
+    });
   });
 }


### PR DESCRIPTION
## Description

Plumb conditional selectors end-to-end through the public parse API and tighten a couple of round-trip / housekeeping issues uncovered while reviewing spec coverage.

- `ChordPro.parse` / `parseSong` now accept `selectors:`; the same set is forwarded to both metadata and formatting reduction, so selector-tagged directives like `{title-guitar: …}` and `{textcolour-print: …}` are gated together. Matching is case-insensitive.
- `reduceFormatting` previously applied every selector-tagged formatting directive unconditionally — last-write-wins regardless of polarity. It now mirrors `reduceMetadata` (`Polarity.positive` / `negative` / `none`).
- `Directive.toString` emits the spec form `{name-!sel}` for negative polarity instead of the legacy `+sel` form. Parsed `+sel` directives are still accepted on input and canonicalize to `-!sel` on round-trip.
- Drop the unused `collection` dependency.
- Document the change set: enumerate every supported metadata directive in the README, mention the new `selectors:` argument, and bump the version to 0.3.0.

New tests cover: abc/ly verbatim blocks, the `{chord}` define-alias, positive / negative / legacy `+sel` / case-insensitive selectors, and selector-aware formatting.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation

## Test plan

- [x] `dart format` clean (36 files)
- [x] `dart analyze` 0 issues
- [x] `dart test` (via Very Good CLI) all green, including the new selector / abc / ly / chord-alias / toString cases