### PR TITLE
feat: add {arranger} metadata directive per ChordPro 6 spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.5.0
+
+* Add `{arranger}` metadata directive
+  ([spec](https://github.com/ChordPro/chordpro/blob/master/docs/content/Directives-arranger.md)).
+  The `Metadata` class gains an `arrangers` field (a list, like `artists`
+  and `composers`). The directive is also recognised when desugared via
+  `{meta: arranger …}`. Previously the value fell silently into
+  `Metadata.other`.
+
 ## 0.4.0
 
 Spec-compliance pass against the ChordPro reference parser.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ print(song.metadata.key);
 
 ### What a `Song` contains
 
-- **`metadata`** — typed `Metadata`: titles, sort titles, subtitles, artists, sort artist, composers, lyricists, copyright, album, year, key, time, tempo, duration, capo, transpose, columns, tags, plus an `other` map for anything custom.
+- **`metadata`** — typed `Metadata`: titles, sort titles, subtitles, artists, sort artist, composers, lyricists, arrangers, copyright, album, year, key, time, tempo, duration, capo, transpose, columns, tags, plus an `other` map for anything custom.
 - **`sections`** — ordered `Section`s for verse, chorus, bridge, tab, grid, abc, ly, svg, textblock, custom environments, and loose lines.
 - **`chordDefinitions`** — parsed `{define}` / `{chord}` bodies.
 - **`formatting`** — typed font / size / colour overrides for chord, text, title, chorus, label, and friends.
@@ -96,7 +96,7 @@ All facts per the [ChordPro chord reference][cp_chords] and [directive reference
 
 ### Directives
 
-- **Metadata** — `title` / `t`, `sorttitle`, `subtitle` / `st`, `artist`, `sortartist`, `composer`, `lyricist`, `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`, `capo`, `transpose`, `columns` / `col`, `tag`, plus `{meta: key value}` desugaring.
+- **Metadata** — `title` / `t`, `sorttitle`, `subtitle` / `st`, `artist`, `sortartist`, `composer`, `lyricist`, `arranger`, `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`, `capo`, `transpose`, `columns` / `col`, `tag`, plus `{meta: key value}` desugaring.
 - **Comments** — `{comment}`, `{ci}`, `{cb}`, `{highlight}` emit as in-flow comment lines.
 - **Images** — `{image: …}` parsed into a typed `ImageDirective`.
 - **Layout breaks** — `{new_page}`, `{new_physical_page}`, `{column_break}` emit as in-flow layout breaks.

--- a/lib/src/ast/metadata.dart
+++ b/lib/src/ast/metadata.dart
@@ -14,6 +14,7 @@ class Metadata {
     this.sortArtist,
     this.composers = const [],
     this.lyricists = const [],
+    this.arrangers = const [],
     this.copyright,
     this.album,
     this.year,
@@ -48,6 +49,9 @@ class Metadata {
 
   /// Lyricists (`{lyricist}`).
   final List<String> lyricists;
+
+  /// Arrangers (`{arranger}`).
+  final List<String> arrangers;
 
   /// Copyright string, stored verbatim.
   final String? copyright;
@@ -97,6 +101,7 @@ class Metadata {
       sortArtist == null &&
       composers.isEmpty &&
       lyricists.isEmpty &&
+      arrangers.isEmpty &&
       copyright == null &&
       album == null &&
       year == null &&
@@ -126,6 +131,7 @@ const Set<String> _listMetadataNames = {
   'artist',
   'composer',
   'lyricist',
+  'arranger',
   'tag',
 };
 
@@ -167,6 +173,7 @@ Metadata reduceMetadata(
   final artists = <String>[];
   final composers = <String>[];
   final lyricists = <String>[];
+  final arrangers = <String>[];
   final tags = <String>[];
   final other = <String, List<String>>{};
   String? sortTitle;
@@ -209,6 +216,8 @@ Metadata reduceMetadata(
           composers.add(value);
         case 'lyricist':
           lyricists.add(value);
+        case 'arranger':
+          arrangers.add(value);
         case 'tag':
           tags.add(value);
       }
@@ -257,6 +266,7 @@ Metadata reduceMetadata(
     sortArtist: sortArtist,
     composers: List.unmodifiable(composers),
     lyricists: List.unmodifiable(lyricists),
+    arrangers: List.unmodifiable(arrangers),
     copyright: copyright,
     album: album,
     year: year,

--- a/lib/src/ast/song.dart
+++ b/lib/src/ast/song.dart
@@ -79,6 +79,7 @@ class Song {
         sortArtist: metadata.sortArtist,
         composers: metadata.composers,
         lyricists: metadata.lyricists,
+        arrangers: metadata.arrangers,
         copyright: metadata.copyright,
         album: metadata.album,
         year: metadata.year,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chord_pro
 description: A Dart parser for the ChordPro 6 song format. Extracts chords, lyrics, metadata, comments, layout hints and chord diagrams.
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/ryzizub/chord_pro
 
 environment:

--- a/test/ast/metadata_test.dart
+++ b/test/ast/metadata_test.dart
@@ -55,6 +55,22 @@ void main() {
       expect(song.metadata.tags, ['holiday', 'acoustic']);
     });
 
+    test('collects arranger list in source order', () {
+      const source = '{arranger: Alice}\n{arranger: Bob}';
+      final song = ChordPro.parseSong(source);
+      expect(song.metadata.arrangers, ['Alice', 'Bob']);
+    });
+
+    test('{meta: arranger …} desugars into arrangers list', () {
+      final song = ChordPro.parseSong('{meta: arranger Eve}');
+      expect(song.metadata.arrangers, ['Eve']);
+    });
+
+    test('arranger populates isEmpty to false', () {
+      final song = ChordPro.parseSong('{arranger: Dave}');
+      expect(song.metadata.isEmpty, isFalse);
+    });
+
     test('keeps x_ custom extensions out of metadata.other', () {
       const source = '{x_myapp_id: 42}\n{mood: bright}';
       final song = ChordPro.parseSong(source);


### PR DESCRIPTION
## Spec drift

Re-verification of the ChordPro 6 spec against the library (`ryzizub/chord_pro @ 0.4.0`) found one unimplemented directive:

**`{arranger}`** — documented as a standard, list-type metadata directive with its own spec page ([`Directives-arranger.md`](https://github.com/ChordPro/chordpro/blob/master/docs/content/Directives-arranger.md)) and listed in the well-known key table in [`Directives-meta.md`](https://github.com/ChordPro/chordpro/blob/master/docs/content/Directives-meta.md). It behaves like `{artist}`, `{composer}`, and `{lyricist}` — multiple occurrences are collected into an ordered list.

Previously the directive value fell silently into `Metadata.other["arranger"]`.

## Changes (single commit)

| File | Change |
|---|---|
| `lib/src/ast/metadata.dart` | Add `arrangers` field; add `'arranger'` to `_listMetadataNames`; handle in `reduceMetadata`; update `isEmpty` |
| `lib/src/ast/song.dart` | Forward `arrangers` through `Song.transposed()` |
| `test/ast/metadata_test.dart` | Three new tests: bare directive, `{meta: arranger …}` desugaring, `isEmpty` |
| `README.md` | Add `arranger` to metadata directive list and supported-features section |
| `CHANGELOG.md` | Add 0.5.0 entry |
| `pubspec.yaml` | Bump version to 0.5.0 |

## Other findings (no action needed)

The following spec items were checked and found to be either already handled, known/documented limitations, or experimental features not yet stable enough to ship:

| Item | Status |
|---|---|
| All environment directives (`verse`, `chorus`, `bridge`, `tab`, `grid`, `abc`, `ly`, `svg`, `textblock`, custom) | ✅ Implemented |
| All other metadata directives (`title`, `artist`, `composer`, `lyricist`, `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`, `capo`, `sorttitle`, `sortartist`, `tag`) | ✅ Implemented |
| Selector polarity — postfix `!` spec form + legacy forms | ✅ Implemented |
| Chord qualities `^`, `h`, `0` | ✅ Implemented (0.4.0) |
| `label="…"` key=value attribute syntax in section start directives | ⚠️ Known limitation (README) |
| `[^]` chord recall notation | ⚠️ Experimental spec feature; spec notes "behaviour may change" |
| `cc` attribute on section start directives | ⚠️ Experimental spec feature |
| `{define}` new attributes (`copy`, `copyall`, `display`, `diagram`, `format`, `keys`) | ℹ️ Rendering/display concern, out of parser scope |

## Test plan

- [ ] `dart pub get`
- [ ] `dart analyze` — no new lint warnings
- [ ] `dart test` — all existing tests pass; three new `arranger` tests pass
- [ ] Confirm `{arranger: Alice}` no longer appears in `metadata.other`
- [ ] Confirm `{meta: arranger Alice}` desugars correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01VgnozCSojzif4rEiiYQ9mr)_