### PR TITLE
docs: restructure README for scannability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,146 +1,155 @@
-### ChordPro
+# chord_pro
 
 [![pub package][pub_package_badge]][pub_package_link]
 [![style: very good analysis][very_good_analysis_badge]][very_good_analysis_link]
 [![License: MIT][license_badge]][license_link]
 
----
+A Dart parser for the [ChordPro 6 song format](https://www.chordpro.org/chordpro/home/).
 
-A Dart parser for the [ChordPro 6 file format](https://www.chordpro.org/chordpro/home/).
-Built for music app developers and digital songbook tooling: extract
-chords, lyrics, metadata, comments, images, layout hints and chord
-diagrams from `.cho`/`.crd`/`.chopro` files.
+Built for music apps and digital songbooks — parses `.cho` / `.crd` / `.chopro` files into typed chords, lyrics, metadata, comments, images, layout hints, and chord diagrams.
 
-## Using
+## Installation
+
+```sh
+dart pub add chord_pro
+```
+
+## Usage
+
+### Parse a document
 
 ```dart
 import 'package:chord_pro/chord_pro.dart';
 
 final result = ChordPro.parse(source);
-for (final song in result.songs) {
-  print(song.metadata.titles.firstOrNull);
-  for (final section in song.sections) {
-    print('${section.kind} ${section.label ?? ''}');
-    for (final line in section.lines) {
-      switch (line.kind) {
-        case LineKind.structured:
-          for (final token in line.tokens) {
-            // TextToken / ChordToken / AnnotationToken / InlineDirectiveToken
-          }
-        case LineKind.verbatim:
-          print(line.verbatim);
-        case LineKind.comment:
-          print('${line.commentStyle}: ${line.comment}');
-        case LineKind.image:
-          print('image: ${line.image?.src}');
-        case LineKind.layoutBreak:
-          print('break: ${line.layoutBreak}');
-      }
+final song = result.songs.first;
+
+print(song.metadata.titles.firstOrNull);
+print(song.metadata.key);
+```
+
+`ChordPro.parse` returns a `ParseResult` with every song in the document (split on `{new_song}` / `{ns}`) plus any diagnostics. Use `ChordPro.parseSong` if you only want the first song.
+
+### What a `Song` contains
+
+- **`metadata`** — typed `Metadata`: titles, sort titles, subtitles, artists, sort artist, composers, lyricists, copyright, album, year, key, time, tempo, duration, capo, transpose, columns, tags, plus an `other` map for anything custom.
+- **`sections`** — ordered `Section`s for verse, chorus, bridge, tab, grid, abc, ly, svg, textblock, custom environments, and loose lines.
+- **`chordDefinitions`** — parsed `{define}` / `{chord}` bodies.
+- **`formatting`** — typed font / size / colour overrides for chord, text, title, chorus, label, and friends.
+- **`directives`** — the raw directive stream in source order.
+- **`customExtensions`** — `x_*` namespaced directives.
+- **`transposed(semitones)`** — returns a copy with every chord shifted.
+
+### Walk sections and lines
+
+```dart
+for (final section in song.sections) {
+  print('${section.kind} ${section.label ?? ''}');
+  for (final line in section.lines) {
+    switch (line.kind) {
+      case LineKind.structured:
+        for (final token in line.tokens) {
+          // TextToken / ChordToken / AnnotationToken / InlineDirectiveToken
+        }
+      case LineKind.verbatim:
+        print(line.verbatim);
+      case LineKind.comment:
+        print('${line.commentStyle}: ${line.comment}');
+      case LineKind.image:
+        print('image: ${line.image?.src}');
+      case LineKind.layoutBreak:
+        print('break: ${line.layoutBreak}');
     }
   }
 }
+```
 
-// Transposition.
+### Transpose and conditional selectors
+
+Shift every chord by N semitones:
+
+```dart
 final upTwo = ChordPro.parseSong(source).transposed(2);
+```
 
-// Conditional selectors (e.g. instrument-specific titles).
+Activate conditional directives like `{title-guitar: …}` / `{title-guitar!: …}` by passing a selector set:
+
+```dart
 final guitar = ChordPro.parseSong(source, selectors: {'guitar'});
 ```
 
-`ChordPro.parse` returns a `ParseResult` with every song in the
-document (split on `{new_song}` / `{ns}`) plus any diagnostics.
-`ChordPro.parseSong` is a convenience that returns the first song.
-Pass `selectors:` to activate conditional directives — see below.
-
-Each `Song` exposes:
-- `metadata` — typed `Metadata` with titles, sort titles, subtitles,
-  artists, sort artist, composers, lyricists, copyright, album,
-  year, key, time, tempo, duration, capo, transpose, columns, tags
-  and an `other` map for anything custom.
-- `sections` — ordered `Section`s for verses, choruses, bridges,
-  tabs, grids, abc, ly, svg, textblock and custom environments,
-  plus loose lines.
-- `chordDefinitions` — parsed `{define}` / `{chord}` bodies.
-- `formatting` — typed font/size/colour overrides for chord, text,
-  title, chorus, label and friends.
-- `directives` — the raw directive stream in source order.
-- `customExtensions` — `x_*` namespaced directives.
-- `transposed(semitones)` — returns a copy with every chord shifted.
+The selector set gates metadata, formatting, sections, comments, images, layout breaks, chord recalls, and `{define}` / `{chord}` definitions. Matching is case-insensitive.
 
 ## Supported features
 
-- Spec-conformant chord notation per the [ChordPro reference][cp_chords]:
-  letter roots (`A`–`G`), Nashville (`1`–`7`), Roman (`I`–`VII`); sharps
-  and flats (`#`/`b`); slash bass; minor variants `m`/`mi`/`min`/`-`;
-  major qualifiers `maj` and the spec alternate `^`; diminished `dim`
-  and the literal-zero `0`; half-diminished `h`; `aug`, `sus`/`sus2`/
-  `sus4`, `add`.
-- Conditional directives — both positive (`{title-guitar: …}`) and
-  spec-form negation (`{title-guitar!: …}`, with `!` postfixed on the
-  selector per the [ChordPro reference parser][cp_directives]). Pass
-  `selectors:` to `ChordPro.parse` / `parseSong` to activate them; the
-  same set gates metadata, formatting, sections, comments, images,
-  layout breaks, chord recalls, and `{define}`/`{chord}` definitions.
-- All section environments — `verse`/`sov`, `chorus`/`soc`, `bridge`/
-  `sob`, `tab`/`sot`, `grid`/`sog`, plus delegated `abc`, `ly`, `svg`
-  and `textblock` captured verbatim. Custom `start_of_<name>` /
-  `end_of_<name>` sections preserved with their custom kind.
-- All metadata directives from the spec — `title`/`t`, `sorttitle`,
-  `subtitle`/`st`, `artist`, `sortartist`, `composer`, `lyricist`,
-  `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`,
-  `capo`, `transpose`, `columns`/`col`, `tag` — plus `{meta: key
-  value}` desugaring.
-- Comment family (`{comment}`, `{ci}`, `{cb}`, `{highlight}`) emitted
-  as in-flow comment lines.
-- `{image: …}` parsed into a typed `ImageDirective`.
-- Page-break and column-break directives as in-flow layout breaks
-  (`{new_page}`, `{new_physical_page}`, `{column_break}`).
-- Font/size/colour directives (`chordfont`, `textsize`,
-  `titlecolour`, …) reduced into `FormattingSettings`. Both `colour`
-  and the American `color` spelling are accepted.
-- Custom `x_*` extensions preserved on `Song.customExtensions` and
-  silently ignored by typed reduction (per spec).
+All facts per the [ChordPro chord reference][cp_chords] and [directive reference][cp_directives].
+
+### Chords
+
+- Letter roots `A`–`G`, Nashville `1`–`7`, Roman `I`–`VII`.
+- Sharps and flats: `#`, `b`.
+- Slash bass.
+- Minor variants: `m`, `mi`, `min`, `-`.
+- Major qualifier `maj` and the spec alternate `^`.
+- Diminished `dim` / `0`, half-diminished `h`.
+- `aug`, `sus`, `sus2`, `sus4`, `add`.
+
+### Directives
+
+- **Metadata** — `title` / `t`, `sorttitle`, `subtitle` / `st`, `artist`, `sortartist`, `composer`, `lyricist`, `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`, `capo`, `transpose`, `columns` / `col`, `tag`, plus `{meta: key value}` desugaring.
+- **Comments** — `{comment}`, `{ci}`, `{cb}`, `{highlight}` emit as in-flow comment lines.
+- **Images** — `{image: …}` parsed into a typed `ImageDirective`.
+- **Layout breaks** — `{new_page}`, `{new_physical_page}`, `{column_break}` emit as in-flow layout breaks.
+- **Formatting** — `chordfont`, `textsize`, `titlecolour`, … reduce into `FormattingSettings`. Both `colour` and `color` accepted.
+- **Custom** — `x_*` extensions preserved on `Song.customExtensions`.
+
+### Sections
+
+- Built-in environments: `verse` / `sov`, `chorus` / `soc`, `bridge` / `sob`, `tab` / `sot`, `grid` / `sog`.
+- Delegated `abc`, `ly`, `svg`, `textblock` captured verbatim.
+- Custom `start_of_<name>` / `end_of_<name>` sections preserved with their custom kind.
+
+### Conditional selectors
+
+- Positive form `{title-guitar: …}` and spec-form negation `{title-guitar!: …}`.
+- Gates metadata, formatting, sections, comments, images, layout breaks, chord recalls, and `{define}` / `{chord}` definitions.
+
+### Source features
+
+- ChordPro 6.01 scanner: trailing `\` line continuation and `\uXXXX` Unicode escapes anywhere in input text.
 - File-level `#` comments dropped.
-- ChordPro 6.01 features: trailing `\`-line continuation and
-  `\uXXXX` Unicode escapes in any input text.
 - Diagnostics with 1-based source spans for every problem.
 
 ## Non-spec extensions
 
-For ergonomic reasons this parser is more lenient than the published
-spec in a few places. Each is opt-in by simply being present in the
-input — your file will still parse, but the named feature is **not**
-required by ChordPro itself:
+The parser is more lenient than the published spec in a few places. Each extension is opt-in by simply being present in your input — files parse either way, but the named feature is **not** required by ChordPro itself.
 
-- `H` as a letter root (German notation for B natural).
-- Unicode accidentals `♯` (U+266F) and `♭` (U+266D).
-- Half-diminished `ø` and diminished `°` glyphs (the spec marks these
-  as `h` and `0`/`dim`).
-- No-chord markers `NC`, `N.C.`, `N.C` (the spec is silent).
-- Backslash-escapes for `[`, `]`, `{`, `}`, `\` inside lyric lines.
-- `{…}` directives appearing mid-lyric (the spec requires directives
-  to occupy a whole line).
-- Legacy negative-selector forms `{name-!sel}` and `{name+sel}`,
-  retained for backward compatibility with older files. New files
-  should use the spec form `{name-sel!}`.
+| Extension                       | Spec equivalent      | Notes                                                  |
+|---------------------------------|----------------------|--------------------------------------------------------|
+| `H` letter root                 | `B`                  | German notation for B natural.                         |
+| `♯` (U+266F), `♭` (U+266D)      | `#`, `b`             | Unicode accidentals.                                   |
+| `ø`, `°`                        | `h`, `0` / `dim`     | Half-diminished and diminished glyphs.                 |
+| `NC`, `N.C.`, `N.C`             | —                    | No-chord markers; spec is silent.                      |
+| Backslash escapes inside lyrics | —                    | Escape `[`, `]`, `{`, `}`, `\` inside lyric lines.     |
+| Mid-lyric `{…}` directives      | —                    | Spec requires directives to occupy a whole line.       |
+| `{name-!sel}`, `{name+sel}`     | `{name-sel!}`        | Legacy negative-selector forms; new files use the spec form. |
 
 ## Known limitations
 
-- The `label="value"` form for section labels is parsed as raw value
-  text; only the bare `{start_of_verse: Verse 1}` form is mapped to
-  `Section.label`.
-- Pango-style markup (`<b>`, `<i>`, `<span …>`, `<sym …/>`, `<img …/>`,
-  `<strut …/>`) inside lyric/comment text is preserved verbatim — no
-  inline parsing is performed.
-- `{define}`'s `format` argument and the associated `\%{` escape are
-  passed through as raw value text.
-- The legacy/no-op directives `pagetype`, `grid`, `no_grid`, `titles`,
-  and `diagrams` land in `Song.directives` only — they are not given
-  typed access.
+- Only the bare `{start_of_verse: Verse 1}` form maps to `Section.label`; the `label="value"` form is parsed as raw value text.
+- Pango-style markup (`<b>`, `<i>`, `<span …>`, `<sym …/>`, `<img …/>`, `<strut …/>`) inside lyrics and comments is preserved verbatim — no inline parsing.
+- `{define}`'s `format` argument and the associated `\%{` escape pass through as raw value text.
+- Legacy / no-op directives `pagetype`, `grid`, `no_grid`, `titles`, `diagrams` land in `Song.directives` only — no typed access.
 
-## Example of chordpro format
+## Example songs
 
-[example song](./example/knockin_on_heavens_door.cho)
+Runnable demo: [`example/chord_pro_example.dart`](./example/chord_pro_example.dart).
+
+ChordPro source files:
+
+- [`knockin_on_heavens_door.cho`](./example/knockin_on_heavens_door.cho)
+- [`house_of_the_rising_sun.cho`](./example/house_of_the_rising_sun.cho)
+- [`scarborough_fair.cho`](./example/scarborough_fair.cho)
 
 [cp_chords]: https://www.chordpro.org/chordpro/chordpro-chords/
 [cp_directives]: https://www.chordpro.org/chordpro/chordpro-directives/


### PR DESCRIPTION
## Description

Reshape `README.md` so readers can skim and find what they need without reading top-to-bottom. Same facts, new structure.

**Top-level changes:**
- Title is now a standard `# chord_pro` h1 (was `### ChordPro`).
- New `## Installation` section with `dart pub add chord_pro`.
- `## Usage` split into focused subsections — *Parse a document* (5-line hello-world), *What a `Song` contains* (one-line per field), *Walk sections and lines*, *Transpose and conditional selectors*.
- `## Supported features` grouped under five subheadings (Chords / Directives / Sections / Conditional selectors / Source features), each bullet trimmed to one line.
- `## Non-spec extensions` rendered as a 3-column table (Extension / Spec equivalent / Notes).
- `## Known limitations` prose tightened to one bullet per line.
- `## Example songs` lists all three `.cho` files plus the runnable `chord_pro_example.dart`.

**Verification:**
- `dart analyze` clean.
- All API symbols referenced in snippets (`ChordPro.parse`, `parseSong`, `LineKind.*`, `ChordToken`, `TextToken`, `Song.transposed`, `selectors:`) cross-checked against `lib/src/`.
- All four `example/` link targets exist.

No code changes outside the README.

## Type of Change

- [x] 📝 Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)