### PR TITLE
fix: ChordPro 6 spec re-verification — '+' augmented quality + image label field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.5.0
+
+ChordPro 6 spec re-verification pass (May 2026).
+
+* Add `+` as a spec-listed augmented quality marker — spec equivalent of
+  `aug` (see <https://www.chordpro.org/chordpro/chordpro-chords/>).
+  Previously `C+` was mis-parsed with extensions `['+']`; it now yields
+  `quality: '+'` and empty extensions.
+* Add `ImageDirective.label` typed field — the `label=` attribute was
+  added to `{image}` in ChordPro 6.040
+  (<https://www.chordpro.org/chordpro/directives-image/>). The value was
+  already captured in `ImageDirective.attributes`; this adds a
+  convenience typed accessor to match `align`, `title`, and the other
+  named fields.
+
 ## 0.4.0
 
 Spec-compliance pass against the ChordPro reference parser.

--- a/lib/src/chord/chord.dart
+++ b/lib/src/chord/chord.dart
@@ -299,7 +299,7 @@ bool _isWhitespace(int c) => c == 0x20 || c == 0x09;
 //   `maj`, `^` (major; `^` is the spec-defined alternate for `maj`)
 //   `dim`, `0` (diminished; `0` is literal digit zero)
 //   `h` (half-diminished)
-//   `aug`, `+`
+//   `aug`, `+` (augmented)
 //   `sus`, `sus2`, `sus4`, `add`
 //
 // Non-spec extensions kept for ergonomic reasons:
@@ -313,6 +313,7 @@ const List<String> _qualities = [
   'sus4',
   'sus',
   'aug',
+  '+', // augmented (spec alternate for `aug`)
   'dim',
   'add',
   'ø', // half-diminished (non-spec; `h` is the spec marker)

--- a/lib/src/directive/image_directive.dart
+++ b/lib/src/directive/image_directive.dart
@@ -18,6 +18,7 @@ class ImageDirective {
     this.align,
     this.border,
     this.title,
+    this.label,
     this.anchor,
     this.id,
   });
@@ -40,10 +41,15 @@ class ImageDirective {
   /// `border=` — frame width.
   final String? border;
 
-  /// `title=` — optional caption.
+  /// `title=` — optional caption (HTML `title` attribute).
   final String? title;
 
-  /// `anchor=` — `inline`, `float`, etc.
+  /// `label=` — visible caption rendered below the image.
+  ///
+  /// Added in ChordPro 6.040.
+  final String? label;
+
+  /// `anchor=` — `inline`, `float`, `allpages`, etc.
   final String? anchor;
 
   /// `id=` — caller-defined identifier.
@@ -103,6 +109,7 @@ ImageDirective? parseImageDirective(
     align: attrs['align'],
     border: attrs['border'],
     title: attrs['title'],
+    label: attrs['label'],
     anchor: attrs['anchor'],
     id: attrs['id'],
     attributes: Map.unmodifiable(attrs),

--- a/test/chord/chord_test.dart
+++ b/test/chord/chord_test.dart
@@ -87,6 +87,19 @@ void main() {
       expect(Chord.tryParse('C0')!.quality, '0');
     });
 
+    test('parses `+` as augmented quality (spec alternate for `aug`)', () {
+      // `+` is the spec-defined alternate for `aug`.
+      final c = Chord.tryParse('C+')!;
+      expect(c.root, 'C');
+      expect(c.quality, '+');
+      expect(c.extensions, isEmpty);
+      // With extension.
+      final c7 = Chord.tryParse('C+7')!;
+      expect(c7.root, 'C');
+      expect(c7.quality, '+');
+      expect(c7.extensions, ['7']);
+    });
+
     test('parses NC as a no-chord marker', () {
       final c = Chord.tryParse('NC')!;
       expect(c.root, 'NC');

--- a/test/directive/image_directive_test.dart
+++ b/test/directive/image_directive_test.dart
@@ -34,6 +34,17 @@ void main() {
       expect(image.title, "it's nice");
     });
 
+    test('parses label attribute (added in ChordPro 6.040)', () {
+      final image = parseImageDirective(
+        'src=cover.png label="My Caption"',
+        span: span,
+      )!;
+      expect(image.src, 'cover.png');
+      expect(image.label, 'My Caption');
+      // Also present in the raw attributes map.
+      expect(image.attributes['label'], 'My Caption');
+    });
+
     test('keeps unknown attributes verbatim', () {
       final image = parseImageDirective('src=x.png frob=42', span: span)!;
       expect(image.attributes['frob'], '42');


### PR DESCRIPTION
## Summary

Re-verification of the library against the ChordPro 6 spec (May 2026) found two drifts. This PR fixes both with one commit per concern plus a CHANGELOG/version bump.

---

### Drift 1 — `+` augmented quality marker missing from chord parser

**Spec reference:** https://www.chordpro.org/chordpro/chordpro-chords/

The spec lists `aug` **and** `+` as equivalent augmented quality markers. The code's own `_qualities` comment already noted this (`aug, +`), but `+` was absent from the actual list. As a result `C+` was mis-parsed: root=`C`, quality=`null`, extensions=`['+']` instead of quality=`'+'`.

**Fix:** add `'+'` immediately after `'aug'` in `_qualities` (`lib/src/chord/chord.dart`).  
**Tests:** two new cases — bare `C+` and `C+7` with an extension.

---

### Drift 2 — `ImageDirective.label` typed field missing

**Spec reference:** https://www.chordpro.org/chordpro/directives-image/ (attribute added in ChordPro 6.040)

ChordPro 6.040 added a `label=` attribute to `{image}` for a visible caption rendered below the image. The attribute was already captured in the generic `ImageDirective.attributes` map, but unlike `align`, `title`, `anchor`, and the other fields it had no typed named accessor.

**Fix:** add `final String? label` to `ImageDirective` and populate it from `attrs['label']` in `parseImageDirective` (`lib/src/directive/image_directive.dart`).  
**Tests:** one new case — parse `{image: src=cover.png label="My Caption"}` and assert both `image.label` and `image.attributes['label']`.

---

### What was checked (no drift)

| Area | Status |
|---|---|
| Metadata directives (`title`, `artist`, `sorttitle`, `sortartist`, `tag`, `composer`, `lyricist`, `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`, `capo`, `transpose`, `columns`) | ✅ all present |
| `{meta: key value}` desugaring | ✅ |
| Section kinds (`verse`, `chorus`, `bridge`, `tab`, `grid`, `abc`, `ly`, `svg`, `textblock`, `custom`) | ✅ all present |
| Selector polarity: `{name-sel}` positive, `{name-sel!}` negative | ✅ |
| Formatting targets (`chord`, `chorus`, `footer`, `grid`, `tab`, `label`, `toc`, `text`, `title`) | ✅ all present, including `label` added in 6.080 |
| Chord quality markers: `maj`, `^`, `m`, `mi`, `min`, `-`, `dim`, `0`, `h`, `aug`, `sus`, `sus2`, `sus4`, `add` | ✅ |
| No-chord markers: `NC`, `N.C.`, `N.C` | ✅ (non-spec extensions, documented) |
| Selector section-end omits selector per spec | ✅ |
| Line continuation (`\` at EOL, v6.010) | ✅ |
| `\uXXXX` Unicode escapes (v6.010) | ✅ |
| `{chorus}` bare recall | ✅ |
| `{define}` / `{chord}` body parsing | ✅ |
| Output-only directives (`{diagrams}`, `{grid}`, `{no_grid}`, `{pagetype}`, `{titles}`) | pass-through only; acceptable for a parsing library |

## Test plan

- [x] `dart pub get` — resolves cleanly
- [x] `dart test` — 133 tests pass, 0 failures
- [x] `dart analyze` — no issues (very_good_analysis lints)
- [x] New chord test: `Chord.tryParse('C+')` → quality `'+'`, `Chord.tryParse('C+7')` → quality `'+'`, extensions `['7']`
- [x] New image test: `parseImageDirective('src=cover.png label="My Caption"')` → `image.label == 'My Caption'`

https://claude.ai/code/session_017wk39UUQmnoJo8YpFjHkWr

---
_Generated by [Claude Code](https://claude.ai/code/session_017wk39UUQmnoJo8YpFjHkWr)_