### PR TITLE
fix: handle {grid}, {no_grid}, and {ng} directives (spec drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Unreleased
+
+### Bug fixes / spec parity
+
+* `{grid}` now enables chord-diagram display (`Song.diagrams.enabled =
+  true`), matching the reference `dir_grid` handler (Song.pm). Previously
+  a bare `{grid}` directive was silently ignored.
+  Spec: <https://www.chordpro.org/chordpro/directives-diagrams/>
+* `{no_grid}` now disables chord-diagram display (`Song.diagrams.enabled =
+  false`), matching the reference `dir_no_grid` handler.
+  Spec: <https://www.chordpro.org/chordpro/directives-diagrams/>
+* `{ng}` is now recognised as the spec-listed abbreviation for `{no_grid}`
+  (from the Song.pm `%abbrevs` hash: `ng => "no_grid"`). Previously `{ng}`
+  was silently dropped.
+  Spec: <https://www.chordpro.org/chordpro/directives-diagrams/>
+
+---
+
 ## 0.5.0
 
 ChordPro 6 spec parity pass against the upstream reference parser

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -142,10 +142,21 @@ ParseResult assemble(
         continue;
       }
 
-      // Diagrams setting. `{g}` is the spec-listed shorthand for
-      // `{diagrams}` per Song.pm:1339.
+      // Diagrams setting.
+      // `{g}` expands to `{diagrams}` per the abbrevs table (Song.pm).
+      // `{grid}` is a distinct directive that *enables* diagram display
+      // (`dir_grid` sets diagrams=1). `{no_grid}`/`{ng}` disable it
+      // (`dir_no_grid` sets diagrams=0) — ref. Song.pm abbrevs hash.
       if (directive.name == 'diagrams' || directive.name == 'g') {
         diagrams = DiagramsSetting.fromValue(directive.value);
+        continue;
+      }
+      if (directive.name == 'grid') {
+        diagrams = const DiagramsSetting(enabled: true);
+        continue;
+      }
+      if (directive.name == 'no_grid' || directive.name == 'ng') {
+        diagrams = const DiagramsSetting(enabled: false);
         continue;
       }
 

--- a/test/assembler/diagrams_setting_test.dart
+++ b/test/assembler/diagrams_setting_test.dart
@@ -53,4 +53,29 @@ void main() {
       expect(ChordPro.parseSong('{title: A}').diagrams, isNull);
     });
   });
+
+  // ChordPro abbrevs: ng => no_grid; dir_grid enables, dir_no_grid disables.
+  // Spec ref: https://www.chordpro.org/chordpro/directives-diagrams/
+  group('{grid} / {no_grid} / {ng} (Song.pm abbrevs + dir_grid/dir_no_grid)', () {
+    test('{grid} enables diagram display', () {
+      final d = ChordPro.parseSong('{grid}').diagrams;
+      expect(d?.enabled, isTrue);
+      expect(d?.position, isNull);
+    });
+
+    test('{no_grid} disables diagram display', () {
+      expect(ChordPro.parseSong('{no_grid}').diagrams?.enabled, isFalse);
+    });
+
+    test('{ng} is the spec alias for {no_grid}', () {
+      expect(ChordPro.parseSong('{ng}').diagrams?.enabled, isFalse);
+    });
+
+    test('{grid} then {no_grid} — last writer wins', () {
+      expect(
+        ChordPro.parseSong('{grid}\n{no_grid}').diagrams?.enabled,
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Spec drift found during a re-verification pass against the ChordPro 6 reference parser (`ChordPro/chordpro` master, Song.pm `%abbrevs` hash + `dir_grid`/`dir_no_grid` handlers).

Three directives were recognised by the upstream parser but silently ignored by this library:

| Directive | Reference behaviour | Upstream location |
|-----------|--------------------|--------------------|
| `{grid}` | Enables chord-diagram display (`diagrams = 1`) | `dir_grid` in Song.pm |
| `{no_grid}` | Disables chord-diagram display (`diagrams = 0`) | `dir_no_grid` in Song.pm |
| `{ng}` | Abbreviation for `no_grid` | Song.pm `%abbrevs`: `ng => "no_grid"` |

Spec reference: https://www.chordpro.org/chordpro/directives-diagrams/

All three now write to `Song.diagrams`, consistent with the existing `{diagrams}` / `{g}` handlers.

## Changes

- **`lib/src/assembler/assembler.dart`** — two new branches in the diagrams-setting block: `{grid}` → `DiagramsSetting(enabled: true)`; `{no_grid}` / `{ng}` → `DiagramsSetting(enabled: false)`.
- **`test/assembler/diagrams_setting_test.dart`** — four new tests covering `{grid}`, `{no_grid}`, `{ng}`, and last-writer-wins ordering.
- **`CHANGELOG.md`** — Unreleased section documenting the three fixes with spec links.

## What was checked (no other drift found)

| Area | Status |
|------|--------|
| All `%abbrevs` entries | ✅ all accounted for except `ng`/`no_grid`/`grid` (fixed here) |
| Section kinds (`verse`, `chorus`, `bridge`, `tab`, `grid`, `abc`, `ly`, `svg`, `textblock`) | ✅ |
| Selector polarity (positive `-sel`, negative `-sel!`, legacy `-!sel`/`+sel`) | ✅ |
| Formatting targets (`chord`, `chorus`, `footer`, `grid`, `tab`, `label`, `toc`, `text`, `title`) | ✅ |
| Metadata keys (`title`, `subtitle`, `artist`, `composer`, `lyricist`, `arranger`, `sorttitle`, `sortartist`, `copyright`, `album`, `year`, `key`, `time`, `tempo`, `duration`, `capo`, `transpose`+qualifier, `columns`, `tag`) | ✅ |
| Chord notation (letter A–H, Nashville 1–7, Roman I/V, accidentals `#`/`b`/`♯`/`♭`, all spec qualities) | ✅ |
| `start_of_grille`/`end_of_grille` | Handled via generic `SectionKind.custom` path (acceptable for a parsing library) |
| `x_*` custom extensions | ✅ via `isCustomExtension` |

## Test plan

- [ ] `dart pub get`
- [ ] `dart test` — new tests in `diagrams_setting_test.dart` all green
- [ ] `dart analyze` — no new lint warnings (very_good_analysis)

> **Note:** The Dart SDK was not available in the review environment so tests could not be executed locally. The logic directly mirrors the three-line `%abbrevs`/`dir_grid`/`dir_no_grid` change in Song.pm and is structurally identical to the existing `{diagrams}`/`{g}` handler.

https://claude.ai/code/session_01Rhca115RdgM518ofSQ7atp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rhca115RdgM518ofSQ7atp)_