### PR TITLE
fix: handle legacy {no_grid}/{ng} as diagrams off (#17)

### DIFF
--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -149,6 +149,13 @@ ParseResult assemble(
         continue;
       }
 
+      // Legacy `{no_grid}` / `{ng}` — obsolete since 6.020 but still
+      // accepted; equivalent to `{diagrams: off}` (Song.pm:1339).
+      if (directive.name == 'no_grid' || directive.name == 'ng') {
+        diagrams = const DiagramsSetting(enabled: false);
+        continue;
+      }
+
       // Selector gate. Per spec, "all directives can be conditionally
       // selected … selection applies to everything in the section, up to
       // and including the final section end directive."

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -1138,6 +1138,12 @@ soft
     test('[§11.h] `{g}` alias for `{diagrams}`', () {
       expect(ChordPro.parseSong('{g: off}').diagrams?.enabled, isFalse);
     });
+
+    test('[§11.i] `{no_grid}` / `{ng}` disable diagrams (legacy, since 3.6)',
+        () {
+      expect(ChordPro.parseSong('{no_grid}').diagrams?.enabled, isFalse);
+      expect(ChordPro.parseSong('{ng}').diagrams?.enabled, isFalse);
+    });
   });
 
   // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #17.

The spec drift audit in #17 surfaced one real gap behind a checklist annotation discrepancy: `chordpro-spec-checklist.md` §11 marks the legacy `{no_grid}` / `{ng}` directives as implemented (`[x]`), but the assembler only handled their `{diagrams}` / `{g}` counterparts. `{no_grid}` and `{ng}` fell through to the generic directive path, so `Song.diagrams` stayed `null` instead of being set to "off".

This maps `{no_grid}` / `{ng}` to `DiagramsSetting(enabled: false)`, mirroring the `{diagrams}` / `{g}` block immediately above it in `assemble()`. Both forms still land in the lossless `Song.directives` stream. With the directives now handled, the `[x]` marks in the checklist are accurate, so no checklist edit is needed.

`{no_grid}` / `{ng}` are obsolete since 6.020 (superseded by `{diagrams}`) but remain accepted for backward compatibility.

## Changes

- `lib/src/assembler/assembler.dart` — map `{no_grid}` / `{ng}` to `DiagramsSetting(enabled: false)`.
- `test/spec_audit_test.dart` — new spec-audit test `[§11.i]` asserting both forms disable diagrams.

## Verification

Run on the committed state:

- `dart format --output=none --set-exit-if-changed .` — exit 0 (0 files changed).
- `dart analyze --fatal-infos` — No issues found.
- `test/spec_audit_test.dart` — 195 passed, 9 skipped (the new `[§11.i]` among them); full suite green via `very_good test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)