### PR TITLE
feat: add SectionKind.grille for start_of_grille delegated environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+### New
+
+* `SectionKind.grille` — recognises `{start_of_grille}` / `{end_of_grille}` as
+  the experimental `Grille.pm` delegated environment from the reference
+  implementation. Previously these fell through to `SectionKind.custom`
+  (non-verbatim); they are now captured verbatim, consistent with other
+  delegated environments (`abc`, `ly`, `svg`, `textblock`).
+  Spec: <https://www.chordpro.org/chordpro/directives-env_grille/>
+
+---
+
 ## 0.6.0
 
 Final ChordPro 6 spec-parity pass: fills the parser-implementable gaps

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ print(song.metadata.key); // first key (use `metadata.keys` for the full list)
 ### What a `Song` contains
 
 - **`metadata`** — typed `Metadata`: titles, sortTitles, subtitles, artists, sortArtists, composers, lyricists, arrangers, copyright, album, year, keys, times, tempos, duration, capo, transpose (plus `transposeQualifier`), columns, tags, plus an `other` map for anything custom. The multi-valued fields preserve source order; convenience getters `key` / `time` / `tempo` / `sortTitle` / `sortArtist` return the first entry.
-- **`sections`** — ordered `Section`s for verse, chorus, bridge, tab, grid, abc, ly, svg, textblock, custom environments, and loose lines. Each section exposes `label`, `attributes`, plus typed `gridAttributes` and `textblockAttributes` where applicable.
+- **`sections`** — ordered `Section`s for verse, chorus, bridge, tab, grid, abc, ly, svg, textblock, grille, custom environments, and loose lines. Each section exposes `label`, `attributes`, plus typed `gridAttributes` and `textblockAttributes` where applicable.
 - **`chordDefinitions`** — parsed `{define}` / `{chord}` bodies including `display`, `format`, `keys`, `copy`, `copyall`, `diagram`, and the transposable bracketed `[Name]` form.
 - **`formatting`** — typed font / size / colour overrides for chord, text, title, chorus, label, and friends.
 - **`directives`** — the raw directive stream in source order.

--- a/chordpro-spec-checklist.md
+++ b/chordpro-spec-checklist.md
@@ -387,6 +387,7 @@ Common rules:
 | [x] `start_of_ly`/`end_of_ly` | Body must start with a line beginning `%` or `\`. Lines before that are **body-prefix formatting instruction lines** — `scale=n` and `center` are body lines, not directive attributes. `\version` and `\header { tagline = ##f }` auto-prepended. | Directive attribute: `label` only. `{transpose}` does NOT cascade. |
 | [x] `start_of_svg`/`end_of_svg` | Body is valid SVG/XML. | Same image-style attrs. |
 | [x] `start_of_textblock`/`end_of_textblock` | Body is text formatted into a placeable image. | Since 6.050. See §6.6. |
+| [x] `start_of_grille`/`end_of_grille` | Experimental delegated environment (`Grille.pm`). Body is chord-grid notation; captured verbatim and processed by the delegate to produce a chord-grid image. | Experimental — present in the `%directives` dispatch table in the reference `Song.pm`. Spec: [directives-env_grille](https://www.chordpro.org/chordpro/directives-env_grille/). Maps to `SectionKind.grille`. |
 
 ### 6.6 Textblock attributes (since 6.050)
 

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -387,6 +387,8 @@ _StartKind? _startKindOf(String name) {
       return _StartKind(SectionKind.svg);
     case 'start_of_textblock':
       return _StartKind(SectionKind.textblock);
+    case 'start_of_grille':
+      return _StartKind(SectionKind.grille);
   }
   if (name.startsWith('start_of_')) {
     return _StartKind(SectionKind.custom, name.substring('start_of_'.length));
@@ -469,6 +471,8 @@ _StartKind? _endKindOf(String name) {
       return _StartKind(SectionKind.svg);
     case 'end_of_textblock':
       return _StartKind(SectionKind.textblock);
+    case 'end_of_grille':
+      return _StartKind(SectionKind.grille);
   }
   if (name.startsWith('end_of_')) {
     return _StartKind(SectionKind.custom, name.substring('end_of_'.length));
@@ -498,7 +502,8 @@ class _OpenSection {
       kind == SectionKind.abc ||
       kind == SectionKind.ly ||
       kind == SectionKind.svg ||
-      kind == SectionKind.textblock;
+      kind == SectionKind.textblock ||
+      kind == SectionKind.grille;
 
   void addLine(RawLine line) {
     if (isVerbatim) {

--- a/lib/src/ast/section.dart
+++ b/lib/src/ast/section.dart
@@ -35,6 +35,14 @@ enum SectionKind {
   /// `{start_of_textblock}` … `{end_of_textblock}` (verbatim).
   textblock,
 
+  /// `{start_of_grille}` … `{end_of_grille}` (verbatim).
+  ///
+  /// Experimental delegated environment in the reference implementation
+  /// (`Grille.pm`). Produces a chord-grid image via the delegate; the body
+  /// is raw chord-grid notation and must be captured verbatim.
+  /// Spec: https://www.chordpro.org/chordpro/directives-env_grille/
+  grille,
+
   /// Custom `{start_of_X}` environment not recognised above.
   custom,
 }

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -647,8 +647,7 @@ real chorus
       final s = ChordPro.parseSong(
         '{start_of_grille}\n| C . | G . |\n{end_of_grille}',
       );
-      final g =
-          s.sections.firstWhere((sec) => sec.kind == SectionKind.grille);
+      final g = s.sections.firstWhere((sec) => sec.kind == SectionKind.grille);
       expect(g.lines.every((l) => l.kind == LineKind.verbatim), isTrue);
     });
 

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -629,6 +629,29 @@ real chorus
       expect(s.sections.any((sec) => sec.kind == SectionKind.svg), isTrue);
     });
 
+    test(
+        '[§6.5-grille] `start_of_grille` recognised as SectionKind.grille '
+        '(experimental delegated environment, Song.pm dispatch table)', () {
+      final s = ChordPro.parseSong(
+        '{start_of_grille}\n| C . | G . |\n{end_of_grille}',
+      );
+      expect(
+        s.sections.any((sec) => sec.kind == SectionKind.grille),
+        isTrue,
+        reason: 'grille must not fall through to custom',
+      );
+    });
+
+    test('[§6.5-grille.verbatim] grille body captured verbatim like abc/ly/svg',
+        () {
+      final s = ChordPro.parseSong(
+        '{start_of_grille}\n| C . | G . |\n{end_of_grille}',
+      );
+      final g =
+          s.sections.firstWhere((sec) => sec.kind == SectionKind.grille);
+      expect(g.lines.every((l) => l.kind == LineKind.verbatim), isTrue);
+    });
+
     test('[§6.6a] textblock attributes (textblock-specific) typed', () {
       final s = ChordPro.parseSong('''
 {start_of_textblock width="200" flush="center" textsize="14"}


### PR DESCRIPTION
## Summary

**Spec drift found:** `{start_of_grille}` / `{end_of_grille}` is explicitly listed in the ChordPro reference implementation's directive dispatch table (`Song.pm`) and maps to the `Grille.pm` delegated environment. Previously the Dart library had no entry for it, so it fell through to `SectionKind.custom` with non-verbatim (chord-parsed) content. The body should be verbatim chord-grid notation, consistent with how `abc`, `ly`, `svg`, and `textblock` delegated environments are handled.

### Changes

- **`lib/src/ast/section.dart`** — adds `SectionKind.grille` enum value (doc-commented as experimental per upstream)
- **`lib/src/assembler/assembler.dart`** — wires `start_of_grille` → `_StartKind(SectionKind.grille)`, `end_of_grille` → matching end kind, and adds `grille` to the `isVerbatim` check so body lines are captured as `LineKind.verbatim`
- **`test/spec_audit_test.dart`** — two new §6.5-grille tests: section kind recognised, body verbatim
- **`chordpro-spec-checklist.md`** — §6.5 table row for `start_of_grille`/`end_of_grille` with spec link
- **`CHANGELOG.md`** and **`README.md`** — updated to mention `grille`

### Upstream reference

Spec page: https://www.chordpro.org/chordpro/directives-env_grille/

The directive appears in `Song.pm`'s `%directives` hash alongside `start_of_grid`, `start_of_verse`, etc. The `Grille.pm` delegate processes chord-grid notation into a rendered chord-grid image. The delegate is marked experimental in the Perl source but the directive is a stable, named entry in the dispatch table (not a custom fallthrough).

### What was checked (no other drift found)

Checked the full ChordPro 6.101.0 surface against the library:

| Area | Status |
|---|---|
| Directive names & abbreviations | ✅ Match |
| Metadata keys (title, artist, key, time, tempo, capo, tag, …) | ✅ Match |
| Section kinds (verse, chorus, bridge, tab, grid, abc, ly, svg, textblock) | ✅ Match — `grille` was the gap |
| Selector polarity (`-sel`, `-sel!`, legacy `+sel`) | ✅ Match |
| Formatting targets (chord, text, title, chorus, footer, grid, tab, label, toc) | ✅ Match |
| Chord roots, accidentals, qualities, extensions, bass slash | ✅ Match |
| Reserved metadata namespace | ✅ Match |
| Stable spec version checked | 6.101.0 (dev branch at 6.101_023, no file-format additions) |

### Test results

```
426 tests passed, 9 skipped (pre-existing AUDIT skips), 0 failed
dart analyze: No issues found
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FX8HZ2osYfygZwLPbPwcy3)_