### PR TITLE
chore: release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Unreleased
+## 0.6.1
+
+Maintenance release: adds the `grille` delegated environment and corrects
+the legacy `{no_grid}` / `{ng}` directives. No breaking changes.
 
 ### New
 
@@ -8,6 +11,14 @@
   (non-verbatim); they are now captured verbatim, consistent with other
   delegated environments (`abc`, `ly`, `svg`, `textblock`).
   Spec: <https://www.chordpro.org/chordpro/directives-env_grille/>
+
+### Fixed
+
+* Legacy `{no_grid}` / `{ng}` now disable chord diagrams (equivalent to
+  `{diagrams: off}`), matching their `{diagrams}` / `{g}` counterparts.
+  Previously they fell through to the generic directive path, leaving
+  `Song.diagrams` unset. Both forms remain in the lossless
+  `Song.directives` stream.
 
 ---
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chord_pro
 description: A Dart parser for the ChordPro 6 song format. Extracts chords, lyrics, metadata, comments, layout hints and chord diagrams.
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/ryzizub/chord_pro
 
 environment:


### PR DESCRIPTION
## Summary

Cuts release **0.6.1** from `main`. Two changes since `v0.6.0`, both non-breaking:

* `feat`: `SectionKind.grille` delegated environment ([#20](https://github.com/ryzizub/chord_pro/pull/20))
* `fix`: legacy `{no_grid}` / `{ng}` disable chord diagrams ([#18](https://github.com/ryzizub/chord_pro/pull/18))

This PR bumps `pubspec.yaml` to `0.6.1` and promotes the `Unreleased` changelog section to `## 0.6.1`. It also **adds the missing changelog entry** for the `{no_grid}` / `{ng}` fix, which was merged without one.

Patch bump per pub semver (no breaking changes).

## Verification

* `dart format` — clean (56 files, 0 changed)
* `dart analyze --fatal-infos` — no issues
* `dart test` — 426 passed, 9 audit skips
* Coverage — 94.88% (CI gate: ≥85%)

After merge, tag the squash-merge commit `v0.6.1` on `main` to mark the release. pub.dev publish (`dart pub publish`) remains a separate manual step.