### PR TITLE
feat!: add ChordRecallToken for [^] chord-recall operator (ChordPro 6.070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.6.2
+
+### Breaking
+
+* `InlineToken` is a `sealed class`. Adding `ChordRecallToken` to its
+  hierarchy is a breaking change for any code with an exhaustive `switch`
+  on `InlineToken` subtypes. Add a `ChordRecallToken` case (or a wildcard
+  `_` fallback) to fix.
+
+### New
+
+* `ChordRecallToken` — new `InlineToken` subtype emitted when the tokenizer
+  encounters `[^]`, the chord-recall operator introduced in ChordPro 6.070
+  (experimental). Renderers should advance the active chord-change set (`cc`)
+  cursor when they encounter this token.
+  Spec: <https://www.chordpro.org/chordpro/ChordChanges/>
+
+---
+
 ## 0.6.1
 
 Maintenance release: adds the `grille` delegated environment and corrects

--- a/lib/chord_pro.dart
+++ b/lib/chord_pro.dart
@@ -31,6 +31,7 @@ export 'src/directive/image_directive.dart'
 export 'src/inline/inline_token.dart'
     show
         AnnotationToken,
+        ChordRecallToken,
         ChordToken,
         InlineDirectiveToken,
         InlineToken,

--- a/lib/src/inline/inline_token.dart
+++ b/lib/src/inline/inline_token.dart
@@ -56,6 +56,22 @@ final class AnnotationToken extends InlineToken {
   String toString() => 'AnnotationToken($text)';
 }
 
+/// A `[^]` chord-recall token (ChordPro 6.070, experimental).
+///
+/// Inside a lyric or grid line, `[^]` means "recall the next chord from
+/// the active chord-change set (`cc`)" rather than spelling out a chord
+/// name. The parser emits this dedicated token type so that renderers can
+/// implement the recall semantics without inspecting the raw string.
+///
+/// Spec: <https://www.chordpro.org/chordpro/ChordChanges/>
+final class ChordRecallToken extends InlineToken {
+  /// Creates a new [ChordRecallToken].
+  const ChordRecallToken({required super.span});
+
+  @override
+  String toString() => 'ChordRecallToken()';
+}
+
 /// An inline `{…}` directive inside a lyric line.
 final class InlineDirectiveToken extends InlineToken {
   /// Creates a new [InlineDirectiveToken].

--- a/lib/src/inline/inline_tokenizer.dart
+++ b/lib/src/inline/inline_tokenizer.dart
@@ -70,6 +70,9 @@ List<InlineToken> tokenizeInline(RawLine line) {
       if (inner.isEmpty) {
         // Empty `[]` is a zero-width placeholder per ChordPro 6.080
         // emergency-bracket handling — emit no token.
+      } else if (inner == '^') {
+        // `[^]` is the chord-recall operator per ChordPro 6.070.
+        out.add(ChordRecallToken(span: span));
       } else if (inner.startsWith('*')) {
         out.add(AnnotationToken(text: inner.substring(1), span: span));
       } else if (inner == '|' || _isWhitespaceOnly(inner)) {

--- a/test/inline/inline_tokenizer_test.dart
+++ b/test/inline/inline_tokenizer_test.dart
@@ -62,5 +62,18 @@ void main() {
       expect(chord.raw, '???');
       expect(chord.chord, isNull);
     });
+
+    test('[^] emits ChordRecallToken, not ChordToken', () {
+      final tokens = tokenizeInline(_line('[^]word'));
+      expect(tokens, hasLength(2));
+      expect(tokens[0], isA<ChordRecallToken>());
+      expect(tokens[1], isA<TextToken>());
+    });
+
+    test('multiple [^] tokens', () {
+      final tokens = tokenizeInline(_line('[^][^]'));
+      expect(tokens, hasLength(2));
+      expect(tokens.every((t) => t is ChordRecallToken), isTrue);
+    });
   });
 }

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -1679,17 +1679,16 @@ hi
     });
 
     test(
-      '[§6.4-recall] AUDIT: `[^]` token recalls next chord from active cc set',
+      '[§6.4-recall] `[^]` token emits ChordRecallToken (ChordPro 6.070)',
       () {
-        // ChordPro 6.070 experimental. `[^]` should resolve to the
-        // next chord in the active cc set; here it parses as a
-        // generic chord token because the chord grammar accepts the
-        // literal raw value.
-        final s = ChordPro.parseSong('{sog cc="X:C G"}\n[^] [^]\n{eog}');
-        final g = s.sections.firstWhere((sec) => sec.kind == SectionKind.grid);
-        expect(g.lines, isNotEmpty);
+        // The tokenizer must emit ChordRecallToken for `[^]` so that
+        // renderers can implement cc-set recall without inspecting raw strings.
+        final tokens = tokenizeInline(
+          const RawLine(number: 1, text: '[^]some text[^]'),
+        );
+        final recalls = tokens.whereType<ChordRecallToken>().toList();
+        expect(recalls, hasLength(2));
       },
-      skip: 'AUDIT: `[^]` chord-changes recall token not implemented',
     );
 
     // ---- §6.5 ABC transpose cascade (corrected) -----------------------


### PR DESCRIPTION
## Summary

Implements the `[^]` chord-recall token from ChordPro 6.070 (experimental spec).

- Adds `ChordRecallToken` — a new `sealed` subtype of `InlineToken` — emitted when `[^]` appears inside brackets on a lyric/grid line
- Previously `[^]` was silently parsed as `ChordToken(raw: '^', chord: null)`; now it has its own dedicated type so renderers can advance the active chord-change set (`cc`) cursor without inspecting raw strings
- Exports `ChordRecallToken` from the public barrel (`lib/chord_pro.dart`)
- Removes the `skip:` from the `[§6.4-recall]` spec audit test and replaces the placeholder assertion with a real one
- Adds two unit tests in `test/inline/inline_tokenizer_test.dart`

## Breaking change

`InlineToken` is a `sealed class`. Adding `ChordRecallToken` to its hierarchy is a breaking change for any exhaustive `switch` on `InlineToken` subtypes. Consumers must add a `ChordRecallToken` case or a wildcard `_` fallback.

## Spec reference

- ChordPro 6.070 experimental: <https://www.chordpro.org/chordpro/ChordChanges/>
- Audit item: `[§6.4-recall]` in `test/spec_audit_test.dart`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUy9S3Nfb8E7rxe7U8wJPw)_