### PR TITLE
feat: add notesMode for lowercase chord roots (ChordPro settings.notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   (experimental). Renderers should advance the active chord-change set (`cc`)
   cursor when they encounter this token.
   Spec: <https://www.chordpro.org/chordpro/ChordChanges/>
+* `notesMode` parameter on `Chord.tryParse`, `tokenizeInline`, `assemble`,
+  `ChordPro.parse`, and `ChordPro.parseSong` — when `true`, lowercase `a`–`g`
+  are accepted as letter-system chord roots, mirroring the `settings.notes`
+  ChordPro configuration option. Defaults to `false`; no behaviour change for
+  existing call sites. Transposition of notes-mode roots is supported through
+  the same chromatic table as uppercase roots.
 
 ---
 

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -521,7 +521,10 @@ class _OpenSection {
       _lines.add(Line.verbatim(verbatim: line.text, span: line.span));
     } else {
       _lines.add(
-        Line(tokens: tokenizeInline(line, notesMode: notesMode), span: line.span),
+        Line(
+          tokens: tokenizeInline(line, notesMode: notesMode),
+          span: line.span,
+        ),
       );
     }
   }

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -23,9 +23,13 @@ import 'package:chord_pro/src/source/source_span.dart';
 /// active when reducing metadata and formatting directives. Matching is
 /// case-insensitive; selectors are folded to lower-case to match what the
 /// directive parser stores.
+///
+/// [notesMode] mirrors the `settings.notes` configuration option: when
+/// `true`, lowercase `a`–`g` are accepted as letter-system chord roots.
 ParseResult assemble(
   String source, {
   Set<String> selectors = const {},
+  bool notesMode = false,
 }) {
   final activeSelectors = selectors.isEmpty
       ? const <String>{}
@@ -243,6 +247,7 @@ ParseResult assemble(
           label: label,
           attributes: Map<String, String>.unmodifiable(attrs),
           startSpan: directive.span,
+          notesMode: notesMode,
         );
         continue;
       }
@@ -253,6 +258,7 @@ ParseResult assemble(
         open ??= _OpenSection(
           kind: SectionKind.loose,
           startSpan: directive.span,
+          notesMode: notesMode,
         );
         open!.addCommentLine(
           text: value,
@@ -267,6 +273,7 @@ ParseResult assemble(
         open ??= _OpenSection(
           kind: SectionKind.loose,
           startSpan: directive.span,
+          notesMode: notesMode,
         );
         open!.addLayoutBreak(kind: layoutBreak, span: directive.span);
         continue;
@@ -298,6 +305,7 @@ ParseResult assemble(
         open ??= _OpenSection(
           kind: SectionKind.loose,
           startSpan: directive.span,
+          notesMode: notesMode,
         );
         open!.addImageLine(image: image, span: directive.span);
         continue;
@@ -346,6 +354,7 @@ ParseResult assemble(
       open = _OpenSection(
         kind: SectionKind.loose,
         startSpan: line.span,
+        notesMode: notesMode,
       );
     }
     open!.addLine(line);
@@ -487,6 +496,7 @@ class _OpenSection {
     this.customKind,
     this.label,
     this.attributes = const {},
+    this.notesMode = false,
   });
 
   final SectionKind kind;
@@ -494,6 +504,7 @@ class _OpenSection {
   final String? label;
   final Map<String, String> attributes;
   final SourceSpan startSpan;
+  final bool notesMode;
   final List<Line> _lines = [];
 
   bool get isVerbatim =>
@@ -510,7 +521,7 @@ class _OpenSection {
       _lines.add(Line.verbatim(verbatim: line.text, span: line.span));
     } else {
       _lines.add(
-        Line(tokens: tokenizeInline(line), span: line.span),
+        Line(tokens: tokenizeInline(line, notesMode: notesMode), span: line.span),
       );
     }
   }

--- a/lib/src/chord/chord.dart
+++ b/lib/src/chord/chord.dart
@@ -59,7 +59,12 @@ class Chord {
   /// Returns `null` if [raw] is empty or starts with whitespace; never
   /// throws. Unknown bodies are captured via [root] + [raw] so callers
   /// can still display them.
-  static Chord? tryParse(String raw) {
+  ///
+  /// When [notesMode] is `true` (mirrors the `settings.notes` config option),
+  /// lowercase `a`–`g` are accepted as letter-system root notes in addition to
+  /// the standard uppercase `A`–`G`. Transposition of notes-mode roots uses
+  /// the same chromatic table as uppercase roots.
+  static Chord? tryParse(String raw, {bool notesMode = false}) {
     if (raw.isEmpty) return null;
     if (_isWhitespace(raw.codeUnitAt(0))) return null;
 
@@ -74,12 +79,12 @@ class Chord {
     final tail = slash < 0 ? null : raw.substring(slash + 1);
     if (head.isEmpty) return null;
 
-    final headParsed = _parseSimple(head);
+    final headParsed = _parseSimple(head, notesMode: notesMode);
     if (headParsed == null) return null;
 
     Chord? bass;
     if (tail != null && tail.isNotEmpty) {
-      final parsedBass = _parseSimple(tail);
+      final parsedBass = _parseSimple(tail, notesMode: notesMode);
       if (parsedBass != null) {
         bass = Chord(
           system: parsedBass.system,
@@ -150,12 +155,15 @@ String? transposeRoot(
 
 String _canonicaliseRoot(String root) {
   if (root.isEmpty) return root;
-  // German H → B natural.
   final canonical = StringBuffer();
   for (var i = 0; i < root.length; i++) {
     final c = root.codeUnitAt(i);
     if (i == 0 && c == 0x48) {
+      // German H → B natural.
       canonical.write('B');
+    } else if (i == 0 && c >= 0x61 && c <= 0x67) {
+      // Notes-mode lowercase a-g → uppercase for chromatic table lookup.
+      canonical.writeCharCode(c - 0x20);
     } else if (c == 0x266F) {
       canonical.write('#');
     } else if (c == 0x266D) {
@@ -217,8 +225,8 @@ class _Parsed {
   final List<String> extensions;
 }
 
-_Parsed? _parseSimple(String s) {
-  final rootEnd = _rootEnd(s);
+_Parsed? _parseSimple(String s, {bool notesMode = false}) {
+  final rootEnd = _rootEnd(s, notesMode: notesMode);
   if (rootEnd == 0) return null;
   final root = s.substring(0, rootEnd);
   final system = _systemFor(root);
@@ -242,10 +250,19 @@ _Parsed? _parseSimple(String s) {
   return _Parsed(system, root, quality, extensions);
 }
 
-int _rootEnd(String s) {
+int _rootEnd(String s, {bool notesMode = false}) {
   final c0 = s.codeUnitAt(0);
   // Letter (A-H) chord. H is German notation for B.
   if ((c0 >= 0x41 && c0 <= 0x47) || c0 == 0x48) {
+    var i = 1;
+    if (i < s.length && _isAccidental(s.codeUnitAt(i))) {
+      i++;
+    }
+    return i;
+  }
+  // Notes mode: lowercase a-g are letter roots (mirrors `settings.notes`).
+  // Checked before the accidental branch so that `b` is a root, not a flat.
+  if (notesMode && c0 >= 0x61 && c0 <= 0x67) {
     var i = 1;
     if (i < s.length && _isAccidental(s.codeUnitAt(i))) {
       i++;
@@ -272,6 +289,8 @@ int _rootEnd(String s) {
 ChordSystem _systemFor(String root) {
   final c0 = root.codeUnitAt(0);
   if ((c0 >= 0x41 && c0 <= 0x47) || c0 == 0x48) return ChordSystem.letter;
+  // Notes-mode lowercase a-g → letter system.
+  if (c0 >= 0x61 && c0 <= 0x67) return ChordSystem.letter;
   if (_isNashvilleDigit(c0) || _isAccidental(c0)) {
     return ChordSystem.nashville;
   }

--- a/lib/src/chord_pro.dart
+++ b/lib/src/chord_pro.dart
@@ -21,13 +21,17 @@ class ChordPro {
   /// [altBrackets] mirrors the `parser.altbrackets` configuration: when
   /// set to a two-character pair (e.g. `«»`), those characters are
   /// rewritten to `[` / `]` before parsing.
+  ///
+  /// [notesMode] mirrors the `settings.notes` configuration option: when
+  /// `true`, lowercase `a`–`g` are accepted as letter-system chord roots.
   static ParseResult parse(
     String source, {
     Set<String> selectors = const {},
     String? altBrackets,
+    bool notesMode = false,
   }) {
     final input = _applyAltBrackets(source, altBrackets);
-    return assemble(input, selectors: selectors);
+    return assemble(input, selectors: selectors, notesMode: notesMode);
   }
 
   /// Convenience wrapper that returns the first song of [source].
@@ -35,11 +39,13 @@ class ChordPro {
     String source, {
     Set<String> selectors = const {},
     String? altBrackets,
+    bool notesMode = false,
   }) =>
       parse(
         source,
         selectors: selectors,
         altBrackets: altBrackets,
+        notesMode: notesMode,
       ).songs.first;
 }
 

--- a/lib/src/inline/inline_tokenizer.dart
+++ b/lib/src/inline/inline_tokenizer.dart
@@ -18,7 +18,10 @@ import 'package:chord_pro/src/source/source_span.dart';
 ///
 /// Backslash escapes (`\[`, `\]`, `\{`, `\}`, `\\`) are honoured and
 /// unescaped in the emitted [TextToken]s.
-List<InlineToken> tokenizeInline(RawLine line) {
+///
+/// When [notesMode] is `true`, lowercase `a`–`g` are accepted as letter
+/// chord roots inside `[…]` brackets (mirrors the `settings.notes` config).
+List<InlineToken> tokenizeInline(RawLine line, {bool notesMode = false}) {
   final text = line.text;
   final out = <InlineToken>[];
   final buffer = StringBuffer();
@@ -82,7 +85,11 @@ List<InlineToken> tokenizeInline(RawLine line) {
         out.add(AnnotationToken(text: inner, span: span));
       } else {
         out.add(
-          ChordToken(raw: inner, chord: Chord.tryParse(inner), span: span),
+          ChordToken(
+            raw: inner,
+            chord: Chord.tryParse(inner, notesMode: notesMode),
+            span: span,
+          ),
         );
       }
       i = closed + 1;

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -1319,13 +1319,25 @@ Swing low, sweet chariot,
     });
 
     test(
-      '[§2.11+] AUDIT: notes mode (lowercase note names) needs config opt-in',
+      '[§2.11+] notesMode accepts lowercase a-g as letter chord roots',
       () {
-        // Spec: `settings.notes` enables solfège or lowercase letters as
-        // chord roots. No surface in this parser.
-        expect(true, isTrue);
+        // `notesMode: true` opts into lowercase letter roots per
+        // `settings.notes`. Standard mode must NOT accept them.
+        final standard = Chord.tryParse('am');
+        expect(standard, isNull, reason: 'am unparseable in standard mode');
+
+        final c = Chord.tryParse('am', notesMode: true);
+        expect(c, isNotNull);
+        expect(c!.system, ChordSystem.letter);
+        expect(c.root, 'a');
+        expect(c.quality, 'm');
+
+        // Full parse round-trip via ChordPro.parseSong.
+        final song = ChordPro.parseSong('[am]word', notesMode: true);
+        final chord =
+            song.sections.first.lines.first.tokens.first as ChordToken;
+        expect(chord.chord?.root, 'a');
       },
-      skip: 'AUDIT: notes-mode configuration not implemented',
     );
   });
 


### PR DESCRIPTION
## Summary

Implements the `settings.notes` configuration option from ChordPro spec §2.11+.

- Adds `notesMode` parameter (default `false`) to `Chord.tryParse`, `tokenizeInline`, `assemble`, `ChordPro.parse`, and `ChordPro.parseSong`
- When `notesMode: true`, lowercase `a`–`g` are accepted as letter-system chord roots in addition to the standard uppercase `A`–`G`
- The notes-mode branch is checked before the flat-accidental branch in `_rootEnd`, so `b` becomes a root note (B) rather than a flat marker when notes mode is active
- `_canonicaliseRoot` is updated to uppercase notes-mode roots, so transposition works identically to their uppercase equivalents
- No breaking change: defaults to `false` everywhere; existing call sites are unaffected
- Removes the `skip:` from `[§2.11+]` spec audit test and replaces the placeholder with a real assertion

## Spec reference

- ChordPro §2.11 `settings.notes`: <https://www.chordpro.org/chordpro/chordpro-configuration-generic/#notes>
- Audit item: `[§2.11+]` in `test/spec_audit_test.dart`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUy9S3Nfb8E7rxe7U8wJPw)_