### PR TITLE
feat: add strict parameter for settings.strict (ChordPro 6.100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   ChordPro configuration option. Defaults to `false`; no behaviour change for
   existing call sites. Transposition of notes-mode roots is supported through
   the same chromatic table as uppercase roots.
+* `strict` parameter on `ChordPro.parse` and `ChordPro.parseSong` (and the
+  internal `assemble`) — when `true`, a `DiagnosticSeverity.warning` is
+  emitted for each song that lacks a `{key}` directive, mirroring the
+  `settings.strict` ChordPro configuration option. Defaults to `false`,
+  consistent with the ChordPro 6.100 change that made forgiving the built-in
+  default.
 
 ---
 

--- a/lib/src/assembler/assembler.dart
+++ b/lib/src/assembler/assembler.dart
@@ -26,10 +26,16 @@ import 'package:chord_pro/src/source/source_span.dart';
 ///
 /// [notesMode] mirrors the `settings.notes` configuration option: when
 /// `true`, lowercase `a`–`g` are accepted as letter-system chord roots.
+///
+/// [strict] mirrors the `settings.strict` ChordPro configuration option.
+/// When `true`, a [DiagnosticSeverity.warning] is emitted for each song that
+/// lacks a `{key}` directive. Defaults to `false`, matching the ChordPro
+/// 6.100 change that flipped the built-in default from strict to forgiving.
 ParseResult assemble(
   String source, {
   Set<String> selectors = const {},
   bool notesMode = false,
+  bool strict = false,
 }) {
   final activeSelectors = selectors.isEmpty
       ? const <String>{}
@@ -76,6 +82,15 @@ ParseResult assemble(
       final s = open!.finish();
       if (s != null) sections.add(s);
       open = null;
+    }
+    if (strict && !directives.any((d) => d.name == 'key')) {
+      diagnostics.add(
+        const Diagnostic(
+          severity: DiagnosticSeverity.warning,
+          message: 'No {key} directive found (required by settings.strict).',
+          span: SourceSpan(line: 1, column: 1, length: 0),
+        ),
+      );
     }
     songs.add(
       Song(

--- a/lib/src/chord_pro.dart
+++ b/lib/src/chord_pro.dart
@@ -24,14 +24,25 @@ class ChordPro {
   ///
   /// [notesMode] mirrors the `settings.notes` configuration option: when
   /// `true`, lowercase `a`–`g` are accepted as letter-system chord roots.
+  ///
+  /// [strict] mirrors `settings.strict`: when `true`, a warning is emitted
+  /// for each song that lacks a `{key}` directive. Defaults to `false`,
+  /// consistent with the ChordPro 6.100 change that made forgiving the
+  /// built-in default.
   static ParseResult parse(
     String source, {
     Set<String> selectors = const {},
     String? altBrackets,
     bool notesMode = false,
+    bool strict = false,
   }) {
     final input = _applyAltBrackets(source, altBrackets);
-    return assemble(input, selectors: selectors, notesMode: notesMode);
+    return assemble(
+      input,
+      selectors: selectors,
+      notesMode: notesMode,
+      strict: strict,
+    );
   }
 
   /// Convenience wrapper that returns the first song of [source].
@@ -40,12 +51,14 @@ class ChordPro {
     Set<String> selectors = const {},
     String? altBrackets,
     bool notesMode = false,
+    bool strict = false,
   }) =>
       parse(
         source,
         selectors: selectors,
         altBrackets: altBrackets,
         notesMode: notesMode,
+        strict: strict,
       ).songs.first;
 }
 

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -1816,15 +1816,36 @@ GABc
     );
 
     test(
-      '[§1.11-settings.strict] AUDIT: `settings.strict` default flipped to '
-      'false in 6.100',
+      '[§1.11-settings.strict] strict=true warns on missing {key}; '
+      'default (false) is forgiving',
       () {
-        // Strict mode rejection is a config decision; the parser is
-        // forgiving by default (matching the new 6.100 default).
-        expect(true, isTrue);
+        // Default (strict=false): no key-missing diagnostic.
+        final lenient = ChordPro.parse('[C]hello');
+        expect(
+          lenient.diagnostics.any(
+            (d) => d.message.contains('{key}'),
+          ),
+          isFalse,
+        );
+
+        // strict=true: a warning is emitted for the missing {key}.
+        final strict = ChordPro.parse('[C]hello', strict: true);
+        expect(
+          strict.diagnostics.any(
+            (d) =>
+                d.severity == DiagnosticSeverity.warning &&
+                d.message.contains('{key}'),
+          ),
+          isTrue,
+        );
+
+        // A song that already has {key} must NOT trigger the warning.
+        final withKey = ChordPro.parse('{key: C}\n[C]hello', strict: true);
+        expect(
+          withKey.diagnostics.any((d) => d.message.contains('{key}')),
+          isFalse,
+        );
       },
-      skip: 'AUDIT: `settings.strict` not toggleable — parser is always '
-          'forgiving (consistent with 6.100 default)',
     );
 
     test('[§1.11-keys.flats] AUDIT: `keys.flats` config (since 6.100)', () {


### PR DESCRIPTION
## Summary

Implements the `settings.strict` configuration option from ChordPro 6.100.

- Adds `strict` parameter (default `false`) to `ChordPro.parse`, `ChordPro.parseSong`, and the internal `assemble` function
- When `strict: true`, a `DiagnosticSeverity.warning` is emitted for each song that lacks a `{key}` directive
- Defaults to `false`, consistent with the ChordPro 6.100 change that flipped the built-in default from strict to forgiving
- No breaking change: defaults to `false` everywhere; existing call sites are unaffected
- Removes the `skip:` from `[§1.11-settings.strict]` spec audit test with a proper three-part assertion (lenient default, strict warning, key-present no-warning)

## Spec reference

- ChordPro `settings.strict` default flip in 6.100
- Audit item: `[§1.11-settings.strict]` in `test/spec_audit_test.dart`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUy9S3Nfb8E7rxe7U8wJPw)_