### PR TITLE
feat: add forceCommonKeys for keys.force-common (ChordPro 6.100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
   `settings.strict` ChordPro configuration option. Defaults to `false`,
   consistent with the ChordPro 6.100 change that made forgiving the built-in
   default.
+* `forceCommonKeys` parameter on `Song.transposed`, `Chord.transpose`, and
+  `transposeRoot` — when `true`, roots that would produce key signatures with
+  more than 5 accidentals are substituted with their enharmonic equivalents:
+  `C#`→`Db`, `D#`→`Eb`, `G#`→`Ab`, `A#`→`Bb`. Mirrors the `keys.force-common`
+  ChordPro 6.100 configuration option. Defaults to `false`; no behaviour change
+  for existing call sites.
 
 ---
 

--- a/lib/src/ast/song.dart
+++ b/lib/src/ast/song.dart
@@ -103,7 +103,8 @@ class Song {
 
     final newKeys = metadata.keys
         .map(
-          (k) => _transposeKey(
+          (k) =>
+              _transposeKey(
                 k,
                 semitones,
                 accidentals,

--- a/lib/src/ast/song.dart
+++ b/lib/src/ast/song.dart
@@ -68,9 +68,15 @@ class Song {
   /// other notations (Nashville, Roman) are key-agnostic and pass
   /// through unchanged. The song key in [Metadata.key] is also remapped
   /// when it points at a recognised root.
+  ///
+  /// When [forceCommonKeys] is `true` (mirrors the `keys.force-common`
+  /// ChordPro 6.100 configuration option), roots that would produce a key
+  /// signature with more than 5 accidentals are substituted with their
+  /// enharmonic equivalents: `C#`→`Db`, `D#`→`Eb`, `G#`→`Ab`, `A#`→`Bb`.
   Song transposed(
     int semitones, {
     AccidentalPreference accidentals = AccidentalPreference.sharps,
+    bool forceCommonKeys = false,
   }) {
     if (semitones % 12 == 0) return this;
     final newSections = sections
@@ -83,7 +89,12 @@ class Song {
             span: s.span,
             lines: s.lines
                 .map(
-                  (line) => _transposeLine(line, semitones, accidentals),
+                  (line) => _transposeLine(
+                    line,
+                    semitones,
+                    accidentals,
+                    forceCommonKeys: forceCommonKeys,
+                  ),
                 )
                 .toList(growable: false),
           ),
@@ -91,7 +102,15 @@ class Song {
         .toList(growable: false);
 
     final newKeys = metadata.keys
-        .map((k) => _transposeKey(k, semitones, accidentals) ?? k)
+        .map(
+          (k) => _transposeKey(
+                k,
+                semitones,
+                accidentals,
+                forceCommonKeys: forceCommonKeys,
+              ) ??
+              k,
+        )
         .toList(growable: false);
 
     return Song(
@@ -138,19 +157,27 @@ class Song {
 String? _transposeKey(
   String? key,
   int semitones,
-  AccidentalPreference accidentals,
-) {
+  AccidentalPreference accidentals, {
+  bool forceCommonKeys = false,
+}) {
   if (key == null) return null;
   final chord = Chord.tryParse(key);
   if (chord == null || chord.system != ChordSystem.letter) return key;
-  return chord.transpose(semitones, accidentals: accidentals).raw;
+  return chord
+      .transpose(
+        semitones,
+        accidentals: accidentals,
+        forceCommonKeys: forceCommonKeys,
+      )
+      .raw;
 }
 
 Line _transposeLine(
   Line line,
   int semitones,
-  AccidentalPreference accidentals,
-) {
+  AccidentalPreference accidentals, {
+  bool forceCommonKeys = false,
+}) {
   if (line.kind != LineKind.structured) return line;
   final newTokens = <InlineToken>[];
   for (final token in line.tokens) {
@@ -158,6 +185,7 @@ Line _transposeLine(
       final transposed = token.chord!.transpose(
         semitones,
         accidentals: accidentals,
+        forceCommonKeys: forceCommonKeys,
       );
       newTokens.add(
         ChordToken(raw: transposed.raw, chord: transposed, span: token.span),

--- a/lib/src/chord/chord.dart
+++ b/lib/src/chord/chord.dart
@@ -112,14 +112,29 @@ class Chord {
   /// other systems are returned unchanged because Nashville and Roman
   /// notation already abstract over key. Returns `this` when the root
   /// is unrecognised.
+  ///
+  /// When [forceCommonKeys] is `true` (mirrors the `keys.force-common`
+  /// ChordPro configuration option), roots that result in key signatures
+  /// with more than 5 accidentals are substituted with their enharmonic
+  /// equivalents: `C#`→`Db`, `D#`→`Eb`, `G#`→`Ab`, `A#`→`Bb`.
   Chord transpose(
     int semitones, {
     AccidentalPreference accidentals = AccidentalPreference.sharps,
+    bool forceCommonKeys = false,
   }) {
     if (system != ChordSystem.letter) return this;
-    final newRoot = transposeRoot(root, semitones, accidentals: accidentals);
+    final newRoot = transposeRoot(
+      root,
+      semitones,
+      accidentals: accidentals,
+      forceCommonKeys: forceCommonKeys,
+    );
     if (newRoot == null) return this;
-    final newBass = bass?.transpose(semitones, accidentals: accidentals);
+    final newBass = bass?.transpose(
+      semitones,
+      accidentals: accidentals,
+      forceCommonKeys: forceCommonKeys,
+    );
     final raw = _renderLetter(newRoot, quality, extensions, newBass);
     return Chord(
       system: system,
@@ -139,19 +154,39 @@ class Chord {
 /// [semitones], returning the transposed spelling or `null` when
 /// [root] is not a recognised letter root. Unicode accidentals
 /// (`♯`/`♭`) and German `H` (= B natural) are accepted on input.
+///
+/// When [forceCommonKeys] is `true`, roots that produce key signatures
+/// with more than 5 accidentals are replaced with their enharmonic
+/// equivalents (`C#`→`Db`, `D#`→`Eb`, `G#`→`Ab`, `A#`→`Bb`).
 String? transposeRoot(
   String root,
   int semitones, {
   AccidentalPreference accidentals = AccidentalPreference.sharps,
+  bool forceCommonKeys = false,
 }) {
   final s = _rootToSemitone[_canonicaliseRoot(root)];
   if (s == null) return null;
   final shifted = (s + semitones) % 12;
   final positive = shifted < 0 ? shifted + 12 : shifted;
-  return accidentals == AccidentalPreference.flats
+  final result = accidentals == AccidentalPreference.flats
       ? _semitoneToFlat[positive]
       : _semitoneToSharp[positive];
+  if (!forceCommonKeys) return result;
+  return _forceCommonKeys[result] ?? result;
 }
+
+/// Enharmonic substitutions applied when `forceCommonKeys=true`.
+///
+/// Replaces roots with more than 5 accidentals in their key signature
+/// with the equivalent flat spelling (≤5 accidentals). Only sharp roots
+/// are affected; flat results from the chromatic table are already ≤6
+/// accidentals and no simpler enharmonic exists.
+const Map<String, String> _forceCommonKeys = {
+  'C#': 'Db', // 7♯ → 5♭
+  'D#': 'Eb', // 9♯ → 3♭
+  'G#': 'Ab', // 8♯ → 4♭
+  'A#': 'Bb', // 10♯ → 2♭
+};
 
 String _canonicaliseRoot(String root) {
   if (root.isEmpty) return root;

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -1882,7 +1882,11 @@ GABc
         for (final entry in sharps.entries) {
           final c = Chord.tryParse(entry.key)!;
           final t = c.transpose(0, forceCommonKeys: true);
-          expect(t.root, entry.value, reason: '${entry.key} with forceCommonKeys');
+          expect(
+            t.root,
+            entry.value,
+            reason: '${entry.key} with forceCommonKeys',
+          );
         }
       },
     );

--- a/test/spec_audit_test.dart
+++ b/test/spec_audit_test.dart
@@ -1859,14 +1859,32 @@ GABc
     });
 
     test(
-      '[§1.11-keys.force-common] AUDIT: `keys.force-common` config '
-      '(since 6.100)',
+      '[§1.11-keys.force-common] forceCommonKeys substitutes '
+      'exotic sharp roots with enharmonic flats',
       () {
-        // Enforces ≤5 accidentals in transposed keys. No surface on
-        // ChordPro.parse / Song.transposed.
-        expect(true, isTrue);
+        // Transposing C up 1 semitone (sharps) → C# without forceCommonKeys.
+        final song = ChordPro.parseSong('{key: C}\n[C]hi');
+        final without = song.transposed(1);
+        final tokenWithout =
+            without.sections.first.lines.first.tokens.first as ChordToken;
+        expect(tokenWithout.chord?.root, 'C#');
+        expect(without.metadata.key, 'C#');
+
+        // With forceCommonKeys: C# (7♯) → Db (5♭).
+        final forced = song.transposed(1, forceCommonKeys: true);
+        final tokenForced =
+            forced.sections.first.lines.first.tokens.first as ChordToken;
+        expect(tokenForced.chord?.root, 'Db');
+        expect(forced.metadata.key, 'Db');
+
+        // D# → Eb, G# → Ab, A# → Bb with forceCommonKeys.
+        final sharps = {'D#': 'Eb', 'G#': 'Ab', 'A#': 'Bb', 'C#': 'Db'};
+        for (final entry in sharps.entries) {
+          final c = Chord.tryParse(entry.key)!;
+          final t = c.transpose(0, forceCommonKeys: true);
+          expect(t.root, entry.value, reason: '${entry.key} with forceCommonKeys');
+        }
       },
-      skip: 'AUDIT: `keys.force-common` enforcement not implemented',
     );
 
     test('[§15-6.101] 6.101 is housekeeping only — no file-format additions',


### PR DESCRIPTION
## Summary

Implements the `keys.force-common` configuration option from ChordPro 6.100.

- Adds `forceCommonKeys` parameter (default `false`) to `transposeRoot`, `Chord.transpose`, and `Song.transposed`
- When `forceCommonKeys: true`, roots with more than 5 accidentals in their key signature are substituted with enharmonic equivalents: `C#`→`Db`, `D#`→`Eb`, `G#`→`Ab`, `A#`→`Bb`
- Substitution is applied as a post-processing step in `transposeRoot` via a `_forceCommonKeys` lookup map
- No breaking change: all parameters default to `false`; existing call sites are unaffected
- Removes the `skip:` from `[§1.11-keys.force-common]` spec audit test with assertions covering the root substitution map, key metadata transposition, and chord token transposition

## Spec reference

- ChordPro 6.100 `keys.force-common` configuration option
- Audit item: `[§1.11-keys.force-common]` in `test/spec_audit_test.dart`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUy9S3Nfb8E7rxe7U8wJPw)_