### PR TITLE
chore: release 0.6.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chord_pro
 description: A Dart parser for the ChordPro 6 song format. Extracts chords, lyrics, metadata, comments, layout hints and chord diagrams.
-version: 0.6.1
+version: 0.6.2
 repository: https://github.com/ryzizub/chord_pro
 
 environment:


### PR DESCRIPTION
## Summary

Bumps `version` in `pubspec.yaml` to `0.6.2` for the pub.dev release. The `CHANGELOG.md` section for 0.6.2 is already on `main`.

Release contents (see [CHANGELOG.md](CHANGELOG.md)):

- **Breaking** — `ChordRecallToken` added to the `sealed` `InlineToken` hierarchy; exhaustive switches need a new case.
- **New** — `ChordRecallToken` for the `[^]` chord-recall operator (ChordPro 6.070).
- **New** — `notesMode` parameter mirroring `settings.notes` (lowercase `a`–`g` roots).
- **New** — `strict` parameter mirroring `settings.strict` (warn on missing `{key}`).
- **New** — `forceCommonKeys` parameter mirroring `keys.force-common`.
- **New** — `Preprocessor` typedef and `preprocessors:` argument on `ChordPro.parse` / `parseSong`.

## Verification

- `dart format --output=none --set-exit-if-changed .` — clean
- `dart analyze --fatal-infos` — no issues
- `very_good test --coverage --min-coverage 85` — 433 passed, 4 `AUDIT:` skips, coverage gate met
- `dart pub publish --dry-run` — no issues beyond the (now committed) version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)